### PR TITLE
make camera clipping distance a little shorter

### DIFF
--- a/src/toniarts/openkeeper/cinematics/Cinematic.java
+++ b/src/toniarts/openkeeper/cinematics/Cinematic.java
@@ -151,6 +151,7 @@ public class Cinematic extends com.jme3.cinematic.Cinematic {
 
                 // Set the near
                 cam.setFrustumNear(FastMath.interpolateLinear(progress, cameraSweepData.getEntries().get(startIndex).getNear(), cameraSweepData.getEntries().get(endIndex).getNear()) / 4096f);
+                cam.setFrustumPerspective(45f, (float) cam.getWidth() / cam.getHeight(), 0.01f, 1000f);
             }
         };
         cameraMotionControl.setLoopMode(LoopMode.DontLoop);


### PR DESCRIPTION
As the clipping distance is pretty high on jmonkey, objects get pretty fast cut through which makes some ugly graphic issues.

Before:
![camera-clip1](https://cloud.githubusercontent.com/assets/3787188/6992724/a63d622c-dadb-11e4-930b-42f56cb9f8b9.PNG)

After:
![camera-clip2](https://cloud.githubusercontent.com/assets/3787188/6992726/aae4f95c-dadb-11e4-8b78-6e57ebbb83e3.PNG)

The example was achieved by setting the y component to 0 instead of 0.35f on Line 64.

See also:
http://hub.jmonkeyengine.org/t/how-to-set-the-camera-near-clipping-distance/17661