### PR TITLE
Refactor conversion process

### DIFF
--- a/src/toniarts/openkeeper/setup/DKConverter.java
+++ b/src/toniarts/openkeeper/setup/DKConverter.java
@@ -36,6 +36,9 @@ public abstract class DKConverter extends javax.swing.JFrame implements IFrameCl
     private final String dungeonKeeperFolder;
     private final AssetManager assetManager;
     private static final Logger logger = Logger.getLogger(DKConverter.class.getName());
+    private int totalProcesses = 0;
+    private int currentProcessNumber = 0;
+    private AssetsConverter.ConvertProcess currentProcess = null;
 
     /**
      * Creates new form DKConverter
@@ -52,6 +55,11 @@ public abstract class DKConverter extends javax.swing.JFrame implements IFrameCl
      * Call to start the conversion
      */
     public void startConversion() {
+        for (AssetsConverter.ConvertProcess item : AssetsConverter.ConvertProcess.values()) {
+            if (item.isOutdated()) {
+                totalProcesses++;
+            }
+        }
 
         // Start conversion
         Converter converter = new Converter(dungeonKeeperFolder, assetManager, this);
@@ -195,8 +203,12 @@ public abstract class DKConverter extends javax.swing.JFrame implements IFrameCl
     }
 
     private void updateStatus(Integer currentProgress, Integer totalProgress, AssetsConverter.ConvertProcess process) {
-        totalProgressBar.setMaximum(AssetsConverter.ConvertProcess.values().length);
-        totalProgressBar.setValue(process.getProcessNumber() - 1);
+        if (!process.equals(currentProcess)) {
+            currentProcessNumber++;
+            currentProcess = process;
+        }
+        totalProgressBar.setMaximum(totalProcesses);
+        totalProgressBar.setValue(currentProcessNumber);
         String progress = "Converting " + process.toString().toLowerCase();
         if (currentProgress != null && totalProgress != null) {
             progress += " (" + currentProgress + " / " + totalProgress + ")";

--- a/src/toniarts/openkeeper/tools/convert/AssetsConverter.java
+++ b/src/toniarts/openkeeper/tools/convert/AssetsConverter.java
@@ -663,6 +663,7 @@ public abstract class AssetsConverter {
         for (final String entry : wad.getWadFileEntries()) {
             try {
                 updateStatus(i, total, ConvertProcess.PATHS);
+                i++;
 
                 // Convert all the KCS entries
                 if (entry.toLowerCase().endsWith(".kcs")) {

--- a/src/toniarts/openkeeper/tools/convert/AssetsConverter.java
+++ b/src/toniarts/openkeeper/tools/convert/AssetsConverter.java
@@ -90,23 +90,18 @@ public abstract class AssetsConverter {
      */
     public enum ConvertProcess {
 
-        TEXTURES(1, 2),
-        MODELS(2, 1),
-        MOUSE_CURSORS(3, 2),
-        MUSIC_AND_SOUNDS(4, 1),
-        INTERFACE_TEXTS(5, 1),
-        PATHS(6, 3),
-        HI_SCORES(7, 1),
-        FONTS(8, 1),
-        MAP_THUMBNAILS(9, 1);
+        TEXTURES(2),
+        MODELS(1),
+        MOUSE_CURSORS(2),
+        MUSIC_AND_SOUNDS(1),
+        INTERFACE_TEXTS(1),
+        PATHS(3),
+        HI_SCORES(1),
+        FONTS(1),
+        MAP_THUMBNAILS(1);
 
-        private ConvertProcess(int processNumber, int version) {
-            this.processNumber = processNumber;
+        private ConvertProcess(int version) {
             this.version = version;
-        }
-
-        public int getProcessNumber() {
-            return this.processNumber;
         }
 
         public int getVersion() {
@@ -134,7 +129,6 @@ public abstract class AssetsConverter {
         public String toString() {
             return super.toString().replace('_', ' ');
         }
-        private final int processNumber;
         private final int version;
         private boolean outdated = false;
     }


### PR DESCRIPTION
- Remove process number from enum and calculate it dynamicly (so we don't
have to care about it if we add/remove items)
- Use the correct number of total conversions needed (was always 8 (max) before)
- Fixed progress of path conversion, since the number was never incremented it stayed 0 all the time