### PR TITLE
Multiple code improvements - squid:UselessParenthesesCheck, squid:S1213, squid:S1066

### DIFF
--- a/src/toniarts/openkeeper/Main.java
+++ b/src/toniarts/openkeeper/Main.java
@@ -101,6 +101,10 @@ public class Main extends SimpleApplication {
     private final static AssetCache assetCache = new SimpleAssetCache();
     private final static AssetCache weakAssetCache = new WeakRefAssetCache();
 
+    private Main() {
+        super(new StatsAppState(), new DebugKeysAppState());
+    }
+
     public static void main(String[] args) throws InvocationTargetException, InterruptedException {
 
         // Create main application instance
@@ -209,7 +213,7 @@ public class Main extends SimpleApplication {
         }
 
         // If everything is ok, we might need to save the setup
-        boolean result = (folderOk && conversionOk);
+        boolean result = folderOk && conversionOk;
         if (result && saveSetup) {
             try {
                 app.getSettings().save(new FileOutputStream(new File(SETTINGS_FILE)));
@@ -219,10 +223,6 @@ public class Main extends SimpleApplication {
         }
 
         return result;
-    }
-
-    private Main() {
-        super(new StatsAppState(), new DebugKeysAppState());
     }
 
     private static void initSettings(Main app) {
@@ -354,10 +354,8 @@ public class Main extends SimpleApplication {
             public void windowClosing(WindowEvent arg0) {
 
                 // See if it is allowed
-                if (frame instanceof IFrameClosingBehavior) {
-                    if (!((IFrameClosingBehavior) frame).canCloseWindow()) {
-                        return; // You shall not pass!
-                    }
+                if (frame instanceof IFrameClosingBehavior && !((IFrameClosingBehavior) frame).canCloseWindow()) {
+                    return; // You shall not pass!
                 }
 
                 synchronized (lock) {
@@ -404,8 +402,8 @@ public class Main extends SimpleApplication {
 
                     // Recording video
                     if (params.containsKey("record")) {
-                        float quality = (getUserSettings().getSettingFloat(Settings.Setting.RECORDER_QUALITY));
-                        int frameRate = (getUserSettings().getSettingInteger(Settings.Setting.RECORDER_FPS));
+                        float quality = getUserSettings().getSettingFloat(Settings.Setting.RECORDER_QUALITY);
+                        int frameRate = getUserSettings().getSettingInteger(Settings.Setting.RECORDER_FPS);
                         getSettings().setFrameRate(frameRate);
                         VideoRecorderAppState recorder = new VideoRecorderAppState(quality, frameRate);
                         String folder = params.get("record");


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
squid:S1066 - Collapsible "if" statements should be merged.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1213
https://dev.eclipse.org/sonar/rules/show/squid:S1066
Please let me know if you have any questions.
George Kankava