### PR TITLE
Multiple code improvements - squid:CommentedOutCodeLine, squid:S1066, squid:S1596, squid:S1068

### DIFF
--- a/src/toniarts/openkeeper/game/trigger/TriggerActionData.java
+++ b/src/toniarts/openkeeper/game/trigger/TriggerActionData.java
@@ -16,7 +16,6 @@
  */
 package toniarts.openkeeper.game.trigger;
 
-import java.util.logging.Logger;
 import toniarts.openkeeper.tools.convert.map.TriggerAction;
 
 /**
@@ -28,7 +27,6 @@ import toniarts.openkeeper.tools.convert.map.TriggerAction;
 public class TriggerActionData extends TriggerData {
 
     private TriggerAction.ActionType actionType;
-    private static final Logger logger = Logger.getLogger(TriggerActionData.class.getName());
 
     public TriggerActionData() {
         super();

--- a/src/toniarts/openkeeper/game/trigger/TriggerControl.java
+++ b/src/toniarts/openkeeper/game/trigger/TriggerControl.java
@@ -94,11 +94,9 @@ public class TriggerControl extends Control {
             }
         }
 
-        if (trigger.getQuantity() == 0) {
-            if (trigger.getParent() != null) {
-                next = trigger.getParent();
-                trigger.detachFromParent();
-            }
+        if (trigger.getQuantity() == 0 && trigger.getParent() != null) {
+            next = trigger.getParent();
+            trigger.detachFromParent();
         }
 
         if (next == null) {

--- a/src/toniarts/openkeeper/game/trigger/TriggerData.java
+++ b/src/toniarts/openkeeper/game/trigger/TriggerData.java
@@ -139,7 +139,7 @@ public abstract class TriggerData {
             return userData.keySet();
         }
 
-        return Collections.EMPTY_SET;
+        return Collections.emptySet();
     }
 
     public boolean hasUserDataKey(String key) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:CommentedOutCodeLine - Sections of code should not be "commented out".
squid:S1066 - Collapsible "if" statements should be merged.
squid:S1596 - Collections.emptyList(), emptyMap() and emptySet() should be used instead of Collections.EMPTY_LIST, EMPTY_MAP and EMPTY_SET.
squid:S1068 - Unused private fields should be removed.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:CommentedOutCodeLine
https://dev.eclipse.org/sonar/rules/show/squid:S1066
https://dev.eclipse.org/sonar/rules/show/squid:S1596
https://dev.eclipse.org/sonar/rules/show/squid:S1068
Please let me know if you have any questions.
George Kankava