### PR TITLE
Fixed NPE in ModelViewer when viewing a Map

### DIFF
--- a/src/toniarts/openkeeper/tools/modelviewer/ModelViewer.java
+++ b/src/toniarts/openkeeper/tools/modelviewer/ModelViewer.java
@@ -396,7 +396,7 @@ public class ModelViewer extends SimpleApplication implements ScreenController {
                     // Load the selected map
                     String file = ((String) selection.get(0)).concat(".kwd").replaceAll(Matcher.quoteReplacement(File.separator), "/");
                     KwdFile kwd = new KwdFile(dkIIFolder, new File(dkIIFolder.concat(file)));
-                    Node spat = (Node) new MapLoader(this.getAssetManager(), kwd, new EffectManagerState(kwdFile, this.getAssetManager()), null) {
+                    Node spat = (Node) new MapLoader(this.getAssetManager(), kwd, new EffectManagerState(kwd, this.getAssetManager()), null) {
                         @Override
                         protected void updateProgress(int progress, int max) {
                             // Do nothing


### PR DESCRIPTION
The EffectManagerState used another KWD variable (the class variable) rather than the local variable.

This caused NullPointerExceptions when loading a Map.