### PR TITLE
check if spat has children before we try to get them

### DIFF
--- a/src/toniarts/openkeeper/tools/modelviewer/ModelViewer.java
+++ b/src/toniarts/openkeeper/tools/modelviewer/ModelViewer.java
@@ -486,11 +486,13 @@ public class ModelViewer extends SimpleApplication implements ScreenController {
         toggleShowNormals();
 
         // Animate!
-        AnimControl animControl = (AnimControl) spat.getChild(0).getControl(AnimControl.class);
-        if (animControl != null) {
-            AnimChannel channel = animControl.createChannel();
-            channel.setAnim("anim");
-            channel.setLoopMode(LoopMode.Loop);
+        if(!spat.getChildren().isEmpty()) {
+            AnimControl animControl = (AnimControl) spat.getChild(0).getControl(AnimControl.class);
+            if (animControl != null) {
+                AnimChannel channel = animControl.createChannel();
+                channel.setAnim("anim");
+                channel.setLoopMode(LoopMode.Loop);
+            }
         }
     }
 


### PR DESCRIPTION
This is an issue in ModelViewer when selecting Terrain in the top dropdown, and a room type in the list dropdown (e.g. Treasury or Lair), these don't have children, so a NPE was produced when the getChild(0) call is done on these.