### PR TITLE
Implement system messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ local.properties
 
 *.dylib
 /build/
+
+# gradle stuff #
+/private/

--- a/assets/Interface/GameHUD.xml
+++ b/assets/Interface/GameHUD.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <nifty xmlns="http://nifty-gui.sourceforge.net/nifty-1.3.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <useStyles filename="nifty-default-styles.xml" />
-    <useStyles filename="Interface/ScrollbarStyle.xml" />
+    <useStyles filename="Interface/ScrollbarSmallStyle.xml" />
     <useStyles filename="Interface/ScrollpanelStyle.xml" />
     <useStyles filename="Interface/CustomTabStyle.xml" />
     <useControls filename="nifty-default-controls.xml" />

--- a/assets/Interface/GameHUD.xml
+++ b/assets/Interface/GameHUD.xml
@@ -81,7 +81,7 @@
             </panel>
             <!--Empty center-->
             <panel childLayout="absolute-inside" height="*" width="100%" id="middle">
-                <control x="45%" y="50%" name="message" id="infoBox" width="450px" height="250px" valign="bottom" paddingRight="20px" paddingBottom="20px" visible="false"/>
+                <control x="45%" y="50%" name="message" width="450px" height="250px" valign="bottom" paddingRight="20px" paddingBottom="20px" visible="false"/>
             </panel>
             <!--The bottom panel-->
             <panel height="220px" width="100%" align="left" valign="bottom" childLayout="overlay">

--- a/assets/Interface/GameHUD.xml
+++ b/assets/Interface/GameHUD.xml
@@ -81,7 +81,7 @@
             </panel>
             <!--Empty center-->
             <panel childLayout="absolute-inside" height="*" width="100%" id="middle">
-                <control x="45%" y="50%" name="message" width="450px" height="250px" valign="bottom" paddingRight="20px" paddingBottom="20px" visible="false"/>
+                <control x="45%" y="50%" name="messageBox" width="450px" height="250px" valign="bottom" paddingRight="20px" paddingBottom="20px" visible="false"/>
             </panel>
             <!--The bottom panel-->
             <panel height="220px" width="100%" align="left" valign="bottom" childLayout="overlay">

--- a/assets/Interface/GameHUD.xml
+++ b/assets/Interface/GameHUD.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <nifty xmlns="http://nifty-gui.sourceforge.net/nifty-1.3.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <useStyles filename="nifty-default-styles.xml" />
+    <useStyles filename="Interface/ScrollbarStyle.xml" />
+    <useStyles filename="Interface/ScrollpanelStyle.xml" />
     <useStyles filename="Interface/CustomTabStyle.xml" />
     <useControls filename="nifty-default-controls.xml" />
     <useControls filename="Interface/MyControls.xml" />
@@ -78,7 +80,9 @@
                 </panel>
             </panel>
             <!--Empty center-->
-            <panel height="*" width="100%" id="middle" />
+            <panel childLayout="absolute-inside" height="*" width="100%" id="middle">
+                <control x="45%" y="50%" name="message" id="infoBox" width="450px" height="250px" valign="bottom" paddingRight="20px" paddingBottom="20px" visible="false"/>
+            </panel>
             <!--The bottom panel-->
             <panel height="220px" width="100%" align="left" valign="bottom" childLayout="overlay">
                 <!-- first bottom layer -->
@@ -142,39 +146,28 @@
                     <!-- bottom middle -->
                     <panel height="100%" width="*" childLayout="overlay">
                         <!-- popup messages and objective -->
-                        <panel width="100%" height="100%" childLayout="vertical">
-                            <panel childLayout="horizontal" width="*" height="64px" paddingLeft="280px">
+                        <panel width="100%" height="100%" childLayout="horizontal" paddingLeft="280px">
+                            <panel childLayout="horizontal" height="64px">
+                                <!-- Show/Hide Panel -->
+                                <image valign="center" filename="Textures/GUI/Icons/i-mise.png" height="64px" width="64px" filter="true" />
                                 <!-- Objective -->
-                                <image valign="center" filename="Textures/GUI/Tabs/Messages/mt-objective-00.png" marginLeft="6px">
+                                <image valign="center" filename="Textures/GUI/Tabs/Messages/mt-objective-00.png">
                                     <effect>
                                         <onHover name="imageOverlay" filename="Textures/GUI/Tabs/Messages/mt-objective-01.png" post="true"/>
                                     </effect>
                                 </image>
+                            </panel>
+                            <panel id="systemMessages" childLayout="horizontal" width="*" height="64px">
                                 <!-- Messages -->
-                                <image valign="center" filename="Textures/GUI/Tabs/Messages/mt-info-00.png" marginLeft="4px">
+                                <!-- Just keeping it as a reference -->
+                                <!-- image valign="center" filename="Textures/GUI/Tabs/Messages/mt-info-00.png" marginLeft="4px" visibleToMouse="true">
                                     <effect>
-                                        <onHover name="imageOverlay" filename="Textures/GUI/Tabs/Messages/mt-info-01.png" post="true"/>
-                                    </effect>
-                                </image>
-                                <image valign="center" filename="Textures/GUI/Tabs/Messages/mt-creature-00.png" marginLeft="4px" visible="false">
-                                    <effect>
-                                        <onHover name="imageOverlay" filename="Textures/GUI/Tabs/Messages/mt-creature-01.png" post="true"/>
-                                    </effect>
-                                </image>
-                                <image valign="center" filename="Textures/GUI/Tabs/Messages/mt-fight-00.png" marginLeft="4px" visible="false">
-                                    <effect>
-                                        <onHover name="imageOverlay" filename="Textures/GUI/Tabs/Messages/mt-fight-01.png" post="true"/>
-                                        <onActive name="imageOverlayPulsate" filename="Textures/GUI/Tabs/Messages/mt-fight-02.png" post="true"/>
-                                    </effect>
-                                </image>
-                                <image valign="center" filename="Textures/GUI/Tabs/Messages/mt-info-00.png" marginLeft="4px" visible="false">
-                                    <effect>
+                                        <onShow name="move" mode="in" direction="right" length="1000" startDelay="0" />
                                         <onHover name="imageOverlay" filename="Textures/GUI/Tabs/Messages/mt-info-01.png" post="true"/>
                                         <onActive name="imageOverlayPulsate" filename="Textures/GUI/Tabs/Messages/mt-info-02.png" post="true"/>
                                     </effect>
-                                </image>
+                                </image -->
                             </panel>
-                            <panel width="100%" height="*" />
                         </panel>
                         <!--The rest-->
                         <control name="customTabGroup" height="100%" width="100%" valign="top" id="tabs-hud">

--- a/assets/Interface/MainMenu.xml
+++ b/assets/Interface/MainMenu.xml
@@ -439,7 +439,7 @@
             </panel>
 
             <control id="moviePanel" name="scrollPanel" align="center" valign="center"
-                     horizontal="false" height="*" width="80%">
+                     horizontal="false" height="*" width="80%" stepSizeY="30">
                 <panel id="movieList" childLayout="vertical">
                     <!-- placeholder for movies -->
                 </panel>

--- a/assets/Interface/MyControls.xml
+++ b/assets/Interface/MyControls.xml
@@ -216,7 +216,7 @@
         </panel>
     </controlDefinition>
 
-    <controlDefinition name="message">
+    <controlDefinition name="message" id="infoBox">
         <panel id="#messageBox" childLayout="vertical">
             <panel id="#messageRowTop" childLayout="horizontal">
                 <image filename="Textures/GUI/Windows/text_box-tl.png" width="16px" height="16px"visibleToMouse="false" />
@@ -240,6 +240,7 @@
                             <effect>
                                 <onHover name="changeImage" active="Textures/GUI/Tabs/Messages/mt-tick-01.png" inactive="Textures/GUI/Tabs/Messages/mt-tick-00.png" />
                                 <onClick name="changeImage" active="Textures/GUI/Tabs/Messages/mt-tick-02.png" inactive="Textures/GUI/Tabs/Messages/mt-tick-00.png" />
+                                <onClick name="hide" targetElement="infoBox" />
                             </effect>
                         </image>
                         <image id="findButton" filename="Textures/GUI/Tabs/Messages/mt-goto-00.png" visibleToMouse="true" marginLeft="30px">

--- a/assets/Interface/MyControls.xml
+++ b/assets/Interface/MyControls.xml
@@ -216,4 +216,56 @@
         </panel>
     </controlDefinition>
 
+    <controlDefinition name="message">
+        <panel id="#messageBox" childLayout="vertical">
+            <panel id="#messageRowTop" childLayout="horizontal">
+                <image filename="Textures/GUI/Windows/text_box-tl.png" width="16px" height="16px"visibleToMouse="false" />
+                <image filename="Textures/GUI/Windows/text_box-t.png" width="*" height="16px" imageMode="repeat:0,0,16,16" visibleToMouse="false" />
+                <image filename="Textures/GUI/Windows/text_box-tr.png" width="16px" height="16px" visibleToMouse="false" />
+            </panel>
+            <panel id="#messageRowCenter" childLayout="horizontal" height="*">
+                <image filename="Textures/GUI/Windows/text_box-l.png" width="16px" height="100%" visibleToMouse="false" imageMode="repeat:0,0,16,16" />
+                <panel width="*" height="*" backgroundImage="Textures/GUI/Windows/text_box-m.png" imageMode="repeat:0,0,16,16" childLayout="vertical">
+                    <control id="#messageScroll" name="scrollPanel" horizontal="false" height="*" stepSizeY="20" paddingBottom="10px">
+                        <control id="messageText" width="98%" name="label" textHAlign="left" style="text" wrap="true" text="$text" />
+                    </control>
+                    <panel id="buttonPanel" childLayout="horizontal" valign="bottom" height="35px">
+                        <image id="dismissButton" filename="Textures/GUI/Tabs/Messages/mt-exit-00.png" visibleToMouse="true" marginLeft="20px">
+                            <effect>
+                                <onHover name="changeImage" active="Textures/GUI/Tabs/Messages/mt-exit-01.png" inactive="Textures/GUI/Tabs/Messages/mt-exit-00.png" />
+                                <onClick name="changeImage" active="Textures/GUI/Tabs/Messages/mt-exit-02.png" inactive="Textures/GUI/Tabs/Messages/mt-exit-00.png" />
+                            </effect>
+                        </image>
+                        <image id="okayButton" filename="Textures/GUI/Tabs/Messages/mt-tick-00.png" visibleToMouse="true" marginLeft="30px">
+                            <effect>
+                                <onHover name="changeImage" active="Textures/GUI/Tabs/Messages/mt-tick-01.png" inactive="Textures/GUI/Tabs/Messages/mt-tick-00.png" />
+                                <onClick name="changeImage" active="Textures/GUI/Tabs/Messages/mt-tick-02.png" inactive="Textures/GUI/Tabs/Messages/mt-tick-00.png" />
+                            </effect>
+                        </image>
+                        <image id="findButton" filename="Textures/GUI/Tabs/Messages/mt-goto-00.png" visibleToMouse="true" marginLeft="30px">
+                            <effect>
+                                <onHover name="changeImage" active="Textures/GUI/Tabs/Messages/mt-goto-01.png" inactive="Textures/GUI/Tabs/Messages/mt-goto-00.png" />
+                                <onClick name="changeImage" active="Textures/GUI/Tabs/Messages/mt-goto-02.png" inactive="Textures/GUI/Tabs/Messages/mt-goto-00.png" />
+                            </effect>
+                        </image>
+                    </panel>
+                </panel>
+                <image filename="Textures/GUI/Windows/text_box-r.png" width="16px" height="100%" visibleToMouse="false" imageMode="repeat:0,0,16,16" />
+            </panel>
+            <panel id="#messageRowBottom" childLayout="horizontal">
+                <image filename="Textures/GUI/Windows/text_box-bl.png" width="16px" height="16px" visibleToMouse="false" />
+                <image filename="Textures/GUI/Windows/text_box-b.png" width="*" height="16px" imageMode="repeat:0,0,16,16" visibleToMouse="false" />
+                <image filename="Textures/GUI/Windows/text_box-br.png" width="16px" height="16px" visibleToMouse="false" />
+            </panel>
+        </panel>
+    </controlDefinition>
+
+    <controlDefinition style="nifty-image-style" name="messageButton">
+        <image filename="Textures/GUI/Tabs/Messages/mt-goto-00.png" marginLeft="30px" visibleToMouse="true">
+            <effect>
+                <onHover name="imageOverlay" filename="Textures/GUI/Tabs/Messages/mt-goto-01.png" />
+                <onClick name="imageOverlay" filename="Textures/GUI/Tabs/Messages/mt-goto-02.png" />
+            </effect>
+        </image>
+    </controlDefinition>
 </nifty-controls>

--- a/assets/Interface/MyControls.xml
+++ b/assets/Interface/MyControls.xml
@@ -216,7 +216,7 @@
         </panel>
     </controlDefinition>
 
-    <controlDefinition name="message" id="messageBox" controller="toniarts.openkeeper.gui.nifty.message.MessageBoxControl">
+    <controlDefinition name="messageBox" id="messageBox" controller="toniarts.openkeeper.gui.nifty.message.MessageBoxControl">
         <panel id="#messageBoxPanel" childLayout="vertical">
             <panel id="#messageRowTop" childLayout="horizontal">
                 <image filename="Textures/GUI/Windows/text_box-tl.png" width="16px" height="16px"visibleToMouse="false" />
@@ -250,6 +250,17 @@
                 <onClick name="imageOverlay" filename="$activeImage" post="true" />
             </effect>
             <interact onClick="$click" />
+        </image>
+    </controlDefinition>
+
+    <controlDefinition name="systemMessage" controller="toniarts.openkeeper.gui.nifty.message.SystemMessageControl" visible="false">
+        <image filename="$image" visibleToMouse="true">
+            <effect>
+                <onHover name="imageOverlay" filename="$hoverImage" post="true"/>
+                <onActive name="imageOverlayPulsate" filename="$activeImage" post="true"/>
+                <onShow name="move" mode="in" direction="right" length="1000" startDelay="0"/>
+            </effect>
+            <interact onClick="showMessage()" />
         </image>
     </controlDefinition>
 </nifty-controls>

--- a/assets/Interface/MyControls.xml
+++ b/assets/Interface/MyControls.xml
@@ -260,7 +260,7 @@
                 <onActive name="imageOverlayPulsate" filename="$activeImage" post="true"/>
                 <onShow name="move" mode="in" direction="right" length="1000" startDelay="0"/>
             </effect>
-            <interact onClick="showMessage()" />
+            <interact onPrimaryClick="showMessage()" onSecondaryRelease="dismissMessage()"/>
         </image>
     </controlDefinition>
 </nifty-controls>

--- a/assets/Interface/MyControls.xml
+++ b/assets/Interface/MyControls.xml
@@ -216,8 +216,8 @@
         </panel>
     </controlDefinition>
 
-    <controlDefinition name="message" id="infoBox">
-        <panel id="#messageBox" childLayout="vertical">
+    <controlDefinition name="message" id="messageBox" controller="toniarts.openkeeper.gui.nifty.message.MessageBoxControl">
+        <panel id="#messageBoxPanel" childLayout="vertical">
             <panel id="#messageRowTop" childLayout="horizontal">
                 <image filename="Textures/GUI/Windows/text_box-tl.png" width="16px" height="16px"visibleToMouse="false" />
                 <image filename="Textures/GUI/Windows/text_box-t.png" width="*" height="16px" imageMode="repeat:0,0,16,16" visibleToMouse="false" />
@@ -230,25 +230,7 @@
                         <control id="messageText" width="98%" name="label" textHAlign="left" style="text" wrap="true" text="$text" />
                     </control>
                     <panel id="buttonPanel" childLayout="horizontal" valign="bottom" height="35px">
-                        <image id="dismissButton" filename="Textures/GUI/Tabs/Messages/mt-exit-00.png" visibleToMouse="true" marginLeft="20px">
-                            <effect>
-                                <onHover name="changeImage" active="Textures/GUI/Tabs/Messages/mt-exit-01.png" inactive="Textures/GUI/Tabs/Messages/mt-exit-00.png" />
-                                <onClick name="changeImage" active="Textures/GUI/Tabs/Messages/mt-exit-02.png" inactive="Textures/GUI/Tabs/Messages/mt-exit-00.png" />
-                            </effect>
-                        </image>
-                        <image id="okayButton" filename="Textures/GUI/Tabs/Messages/mt-tick-00.png" visibleToMouse="true" marginLeft="30px">
-                            <effect>
-                                <onHover name="changeImage" active="Textures/GUI/Tabs/Messages/mt-tick-01.png" inactive="Textures/GUI/Tabs/Messages/mt-tick-00.png" />
-                                <onClick name="changeImage" active="Textures/GUI/Tabs/Messages/mt-tick-02.png" inactive="Textures/GUI/Tabs/Messages/mt-tick-00.png" />
-                                <onClick name="hide" targetElement="infoBox" />
-                            </effect>
-                        </image>
-                        <image id="findButton" filename="Textures/GUI/Tabs/Messages/mt-goto-00.png" visibleToMouse="true" marginLeft="30px">
-                            <effect>
-                                <onHover name="changeImage" active="Textures/GUI/Tabs/Messages/mt-goto-01.png" inactive="Textures/GUI/Tabs/Messages/mt-goto-00.png" />
-                                <onClick name="changeImage" active="Textures/GUI/Tabs/Messages/mt-goto-02.png" inactive="Textures/GUI/Tabs/Messages/mt-goto-00.png" />
-                            </effect>
-                        </image>
+                        <!-- the buttons to click are inserted here -->
                     </panel>
                 </panel>
                 <image filename="Textures/GUI/Windows/text_box-r.png" width="16px" height="100%" visibleToMouse="false" imageMode="repeat:0,0,16,16" />
@@ -262,11 +244,12 @@
     </controlDefinition>
 
     <controlDefinition style="nifty-image-style" name="messageButton">
-        <image filename="Textures/GUI/Tabs/Messages/mt-goto-00.png" marginLeft="30px" visibleToMouse="true">
+        <image filename="$image" visibleToMouse="true" marginLeft="30px">
             <effect>
-                <onHover name="imageOverlay" filename="Textures/GUI/Tabs/Messages/mt-goto-01.png" />
-                <onClick name="imageOverlay" filename="Textures/GUI/Tabs/Messages/mt-goto-02.png" />
+                <onHover name="imageOverlay" filename="$hoverImage" post="true" />
+                <onClick name="imageOverlay" filename="$activeImage" post="true" />
             </effect>
+            <interact onClick="$click" />
         </image>
     </controlDefinition>
 </nifty-controls>

--- a/assets/Interface/ScrollbarSmallStyle.xml
+++ b/assets/Interface/ScrollbarSmallStyle.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<nifty-styles xmlns="http://nifty-gui.lessvoid.com/nifty-gui">
+    <!-- ++++++++++++++ -->
+    <!-- vertical small -->
+    <!-- ++++++++++++++ -->
+    <style id="nifty-vertical-scrollbar#panel">
+        <attributes childLayout="vertical" width="20px" align="center" focusable="false"/>
+    </style>
+    <style id="nifty-vertical-scrollbar#up">
+        <attributes filename="Textures/GUI/Scroll Bars/v-up_arrow.png" width="16px" height="16px" />
+        <effect>
+            <onClick name="focus" targetElement="#parent"/>
+            <onEnabled name="renderQuad" startColor="#2228" endColor="#2220" post="true" length="150"/>
+            <onDisabled name="renderQuad" startColor="#2220" endColor="#2228" post="true" length="150"/>
+        </effect>
+    </style>
+    <style id="nifty-vertical-scrollbar#down">
+        <attributes filename="Textures/GUI/Scroll Bars/v-down_arrow.png" width="16px" height="16px"/>
+        <effect>
+            <onClick name="focus" targetElement="#parent"/>
+            <onEnabled name="renderQuad" startColor="#2228" endColor="#2220" post="true" length="150" />
+            <onDisabled name="renderQuad" startColor="#2220" endColor="#2228" post="true" length="150" />
+        </effect>
+    </style>
+    <style id="nifty-vertical-scrollbar#background">
+        <attributes filename="Textures/GUI/Scroll Bars/v-scroll_bar_bg.png" padding="1px,4px,1px,5px" width="16px" height="*" 
+                    childLayout="absolute-inside" imageMode="repeat:0,0,16,16" />
+        <effect>
+            <onClick name="focus" targetElement="#parent"/>
+            <onHover name="fade" start="#ff" end="#af" post="true" />
+        </effect>
+    </style>
+    <style id="nifty-vertical-scrollbar#position">
+        <attributes filename="Textures/GUI/Scroll Bars/v-scroll_bar.png" x="0px" y="0px" width="16px" height="64px" />
+        <effect>
+            <onClick name="focus" targetElement="#parent#parent"/>
+            <onEnabled name="renderQuad" startColor="#2228" endColor="#2220" post="true" length="150" />
+            <onDisabled name="renderQuad" startColor="#2220" endColor="#2228" post="true" length="150" />
+        </effect>
+    </style>
+
+    <!-- ++++++++++ -->
+    <!-- horizontal -->
+    <!-- ++++++++++ -->
+    <style id="nifty-horizontal-scrollbar#panel">
+        <attributes childLayout="horizontal" height="16px" align="center" focusable="true" />
+    </style>
+    <style id="nifty-horizontal-scrollbar#left">
+        <attributes filename="Textures/GUI/Scroll Bars/H-left_arrow.png" valign="center" width="16px" height="16px" />
+        <effect>
+            <onClick name="focus" targetElement="#parent"/>
+            <onEnabled name="renderQuad" startColor="#2228" endColor="#2220" post="true" length="150"/>
+            <onDisabled name="renderQuad" startColor="#2220" endColor="#2228" post="true" length="150"/>
+        </effect>
+    </style>
+    <style id="nifty-horizontal-scrollbar#right">
+        <attributes filename="Textures/GUI/Scroll Bars/h-right_arrow.png" valign="center" width="16px" height="16px" />
+        <effect>
+            <onClick name="focus" targetElement="#parent"/>
+            <onEnabled name="renderQuad" startColor="#2228" endColor="#2220" post="true" length="150"/>
+            <onDisabled name="renderQuad" startColor="#2220" endColor="#2228" post="true" length="150"/>
+        </effect>
+    </style>
+    <style id="nifty-horizontal-scrollbar#background">
+        <attributes filename="Textures/GUI/Scroll Bars/h-scroll_bar_bg.png" padding="4px,1px,5px,1px" width="*" height="16px" 
+                    childLayout="absolute-inside" imageMode="repeat:0,0,16,16"/>
+        <effect>
+            <onClick name="focus" targetElement="#parent"/>
+            <onHover name="fade" start="#ff" end="#af" post="true" />
+        </effect>
+    </style>
+    <style id="nifty-horizontal-scrollbar#position">
+        <attributes filename="Textures/GUI/Scroll Bars/h-scroll_bar.png" x="0px" y="0px" width="64px" height="16px" />
+        <effect>
+            <onClick name="focus" targetElement="#parent#parent"/>
+            <onEnabled name="renderQuad" startColor="#2228" endColor="#2220" post="true" length="150"/>
+            <onDisabled name="renderQuad" startColor="#2220" endColor="#2228" post="true" length="150"/>
+        </effect>
+    </style>
+</nifty-styles>

--- a/src/toniarts/openkeeper/game/state/GameState.java
+++ b/src/toniarts/openkeeper/game/state/GameState.java
@@ -152,6 +152,8 @@ public class GameState extends AbstractPauseAwareState implements IGameLogicUpda
                     GameState.this.stateManager.attach(worldState);
 
                     GameState.this.stateManager.attach(new SoundState(false));
+
+                    GameState.this.stateManager.attach(new SystemMessageState(app, false));
                     setProgress(0.60f);
 
                     GameState.this.stateManager.attach(new PartyState(false));
@@ -255,6 +257,7 @@ public class GameState extends AbstractPauseAwareState implements IGameLogicUpda
                 GameState.this.stateManager.getState(ActionPointState.class).setEnabled(true);
                 GameState.this.stateManager.getState(PartyState.class).setEnabled(true);
                 GameState.this.stateManager.getState(SoundState.class).setEnabled(true);
+                GameState.this.stateManager.getState(SystemMessageState.class).setEnabled(true);
 
                 // Set initialized
                 GameState.this.initialized = true;

--- a/src/toniarts/openkeeper/game/state/SystemMessageState.java
+++ b/src/toniarts/openkeeper/game/state/SystemMessageState.java
@@ -23,6 +23,7 @@ import de.lessvoid.nifty.builder.HoverEffectBuilder;
 import de.lessvoid.nifty.builder.ImageBuilder;
 import de.lessvoid.nifty.effects.EffectEventId;
 import de.lessvoid.nifty.elements.Element;
+import de.lessvoid.nifty.screen.Screen;
 import toniarts.openkeeper.Main;
 import toniarts.openkeeper.gui.nifty.SystemMessageControl;
 import toniarts.openkeeper.tools.convert.ConversionUtils;
@@ -33,7 +34,9 @@ import toniarts.openkeeper.tools.convert.ConversionUtils;
 public class SystemMessageState extends AbstractPauseAwareState {
     private final float lifeTime = 60000f;
     private final Nifty nifty;
-    private Main app = null;
+    private final Main app;
+    private final Screen hud;
+    private final Element systemMessagesQueue;
 
     public enum MessageType {
         INFO,
@@ -44,14 +47,12 @@ public class SystemMessageState extends AbstractPauseAwareState {
         CREATURE
     };
 
-    SystemMessageState(Nifty nifty, boolean enabled) {
-        this.nifty = nifty;
-        this.setEnabled(enabled);
-    }
-
     SystemMessageState(Main app, boolean enabled) {
         this.nifty = app.getNifty().getNifty();
         this.app = app;
+        this.hud = nifty.getScreen("hud");
+        this.systemMessagesQueue = this.hud.findElementById("systemMessages");
+
         this.setEnabled(enabled);
     }
     
@@ -104,17 +105,14 @@ public class SystemMessageState extends AbstractPauseAwareState {
             set("text", text);
             controller(SystemMessageControl.class.getName());
             interactOnClick("showMessage()");
-        }}.build(nifty, nifty.getScreen("hud"), nifty.getScreen("hud").findElementById("systemMessages"));
+        }}.build(nifty, this.hud, systemMessagesQueue);
         image.show();
-        
-        syncActiveEffects();
     }
     
     @Override
     public void update(float tpf) {
-        Element systemMessages = nifty.getScreen("hud").findElementById("systemMessages");
-        if (systemMessages != null) {
-            for(Element child : systemMessages.getChildren()) {
+        if (systemMessagesQueue != null) {
+            for(Element child : systemMessagesQueue.getChildren()) {
                 SystemMessageControl control = child.getControl(SystemMessageControl.class);
                 if (control != null && System.currentTimeMillis() - control.getCreatedAt() > lifeTime) {
                     child.markForRemoval();

--- a/src/toniarts/openkeeper/game/state/SystemMessageState.java
+++ b/src/toniarts/openkeeper/game/state/SystemMessageState.java
@@ -18,9 +18,7 @@ package toniarts.openkeeper.game.state;
 
 import de.lessvoid.nifty.Nifty;
 import de.lessvoid.nifty.NiftyIdCreator;
-import de.lessvoid.nifty.builder.EffectBuilder;
-import de.lessvoid.nifty.builder.HoverEffectBuilder;
-import de.lessvoid.nifty.builder.ImageBuilder;
+import de.lessvoid.nifty.builder.ControlBuilder;
 import de.lessvoid.nifty.elements.Element;
 import de.lessvoid.nifty.screen.Screen;
 import toniarts.openkeeper.Main;
@@ -81,31 +79,13 @@ public class SystemMessageState extends AbstractPauseAwareState {
         final String hoverIcon = ConversionUtils.getCanonicalAssetKey(icon.replace("$index", "01"));
         final String activeIcon = ConversionUtils.getCanonicalAssetKey(icon.replace("$index", "02"));
         
-        Element image = new ImageBuilder("sysmessage-" + NiftyIdCreator.generate()){{
-            filename(normalIcon);
-            //marginLeft("4px");
-            visibleToMouse(true);
-            visible(false);
-            onHoverEffect(new HoverEffectBuilder("imageOverlay"){{
-                // using filename leads to an NPE, no idea why...
-                getAttributes().setAttribute("filename", hoverIcon);
-                post(true);
-            }});
-            onActiveEffect(new EffectBuilder("imageOverlayPulsate"){{
-                getAttributes().setAttribute("filename", activeIcon);
-                post(true);
-            }});
-            onShowEffect(new EffectBuilder("move"){{
-                getAttributes().setAttribute("mode", "in");
-                getAttributes().setAttribute("direction", "right");
-                length(1000);
-                startDelay(0);
-            }});
+        Element systemMessage = new ControlBuilder("sysmessage-" + NiftyIdCreator.generate(), "systemMessage"){{
+            parameter("image", normalIcon);
+            parameter("hoverImage", hoverIcon);
+            parameter("activeImage", activeIcon);
             set("text", text);
-            controller(SystemMessageControl.class.getName());
-            interactOnClick("showMessage()");
         }}.build(nifty, this.hud, systemMessagesQueue);
-        image.show();
+        systemMessage.show();
     }
     
     @Override

--- a/src/toniarts/openkeeper/game/state/SystemMessageState.java
+++ b/src/toniarts/openkeeper/game/state/SystemMessageState.java
@@ -17,6 +17,7 @@
 package toniarts.openkeeper.game.state;
 
 import de.lessvoid.nifty.Nifty;
+import de.lessvoid.nifty.NiftyIdCreator;
 import de.lessvoid.nifty.builder.EffectBuilder;
 import de.lessvoid.nifty.builder.HoverEffectBuilder;
 import de.lessvoid.nifty.builder.ImageBuilder;
@@ -32,7 +33,6 @@ import toniarts.openkeeper.tools.convert.ConversionUtils;
 public class SystemMessageState extends AbstractPauseAwareState {
     private final float lifeTime = 60000f;
     private final Nifty nifty;
-    private int counter = 0;
     private Main app = null;
 
     public enum MessageType {
@@ -81,7 +81,7 @@ public class SystemMessageState extends AbstractPauseAwareState {
         final String hoverIcon = ConversionUtils.getCanonicalAssetKey(icon.replace("$index", "01"));
         final String activeIcon = ConversionUtils.getCanonicalAssetKey(icon.replace("$index", "02"));
         
-        Element image = new ImageBuilder("sysmessage.id" + counter++){{
+        Element image = new ImageBuilder("sysmessage-" + NiftyIdCreator.generate()){{
             filename(normalIcon);
             //marginLeft("4px");
             visibleToMouse(true);

--- a/src/toniarts/openkeeper/game/state/SystemMessageState.java
+++ b/src/toniarts/openkeeper/game/state/SystemMessageState.java
@@ -21,11 +21,10 @@ import de.lessvoid.nifty.NiftyIdCreator;
 import de.lessvoid.nifty.builder.EffectBuilder;
 import de.lessvoid.nifty.builder.HoverEffectBuilder;
 import de.lessvoid.nifty.builder.ImageBuilder;
-import de.lessvoid.nifty.effects.EffectEventId;
 import de.lessvoid.nifty.elements.Element;
 import de.lessvoid.nifty.screen.Screen;
 import toniarts.openkeeper.Main;
-import toniarts.openkeeper.gui.nifty.SystemMessageControl;
+import toniarts.openkeeper.gui.nifty.message.SystemMessageControl;
 import toniarts.openkeeper.tools.convert.ConversionUtils;
 /**
  *

--- a/src/toniarts/openkeeper/game/state/SystemMessageState.java
+++ b/src/toniarts/openkeeper/game/state/SystemMessageState.java
@@ -44,11 +44,14 @@ public class SystemMessageState extends AbstractPauseAwareState {
         CREATURE
     };
 
-    SystemMessageState(Main app, boolean enabled) {
+    public SystemMessageState(Main app, boolean enabled) {
         this.nifty = app.getNifty().getNifty();
         this.app = app;
         this.hud = nifty.getScreen("hud");
         this.systemMessagesQueue = this.hud.findElementById("systemMessages");
+
+        // can be removed if system messages are correctly detached after quiting the game (like going back to main menu)
+        this.removeAllMessages();
 
         this.setEnabled(enabled);
     }
@@ -103,5 +106,22 @@ public class SystemMessageState extends AbstractPauseAwareState {
     @Override
     public boolean isPauseable() {
         return true;
+    }
+
+    /**
+     * Removes all existing messages from the queue
+     */
+    public void removeAllMessages() {
+        if (systemMessagesQueue != null && systemMessagesQueue.getChildrenCount() > 0) {
+            systemMessagesQueue.getChildren().forEach((child)->{
+                child.markForRemoval();
+            });
+        }
+    }
+
+    @Override
+    public void cleanup() {
+        super.cleanup();
+        this.removeAllMessages();
     }
 }

--- a/src/toniarts/openkeeper/game/state/SystemMessageState.java
+++ b/src/toniarts/openkeeper/game/state/SystemMessageState.java
@@ -122,23 +122,7 @@ public class SystemMessageState extends AbstractPauseAwareState {
             }
         }
     }
-    
-    /**
-     * Used to sync the effect on active messages.
-     * Otherwise all messages pulsate differently, which looks odd.
-     */
-    public void syncActiveEffects() {
-        Element systemMessages = nifty.getScreen("hud").findElementById("systemMessages");
-        if (systemMessages != null) {
-            for(Element child : systemMessages.getChildren()) {
-                SystemMessageControl control = child.getControl(SystemMessageControl.class);
-                if (control != null && control.isUnread()) {
-                    child.startEffect(EffectEventId.onActive);
-                }
-            }
-        }
-    }
-    
+
     @Override
     public boolean isPauseable() {
         return true;

--- a/src/toniarts/openkeeper/game/state/SystemMessageState.java
+++ b/src/toniarts/openkeeper/game/state/SystemMessageState.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2014-2015 OpenKeeper
+ *
+ * OpenKeeper is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * OpenKeeper is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenKeeper.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package toniarts.openkeeper.game.state;
+
+import de.lessvoid.nifty.Nifty;
+import de.lessvoid.nifty.builder.EffectBuilder;
+import de.lessvoid.nifty.builder.HoverEffectBuilder;
+import de.lessvoid.nifty.builder.ImageBuilder;
+import de.lessvoid.nifty.effects.EffectEventId;
+import de.lessvoid.nifty.elements.Element;
+import toniarts.openkeeper.Main;
+import toniarts.openkeeper.gui.nifty.SystemMessageControl;
+import toniarts.openkeeper.tools.convert.ConversionUtils;
+/**
+ *
+ * @author ufdada
+ */
+public class SystemMessageState extends AbstractPauseAwareState {
+    private final float lifeTime = 60000f;
+    private final Nifty nifty;
+    private int counter = 0;
+    private Main app = null;
+
+    public enum MessageType {
+        INFO,
+        FIGHT,
+        ALLY,
+        ALLYMSG,
+        PLAYEREXIT,
+        CREATURE
+    };
+
+    SystemMessageState(Nifty nifty, boolean enabled) {
+        this.nifty = nifty;
+        this.setEnabled(enabled);
+    }
+
+    SystemMessageState(Main app, boolean enabled) {
+        this.nifty = app.getNifty().getNifty();
+        this.app = app;
+        this.setEnabled(enabled);
+    }
+    
+    /**
+     * Adds a message to the message queue
+     * 
+     * @param type
+     * @param text
+     */
+    public void addMessage(MessageType type, String text) {
+        if (!this.isEnabled()) {
+            return;
+        }
+        if (this.app != null) {
+            this.app.enqueue(()-> {
+                this.addMessageIcon(type, text);
+                return null;
+            });
+        } else {
+            this.addMessageIcon(type, text);
+        }
+    }
+    
+    public void addMessageIcon(MessageType type, String text) {
+        final String icon = String.format("Textures/GUI/Tabs/Messages/mt-%s-$index.png", type.toString().toLowerCase());
+        final String normalIcon = ConversionUtils.getCanonicalAssetKey(icon.replace("$index", "00"));
+        final String hoverIcon = ConversionUtils.getCanonicalAssetKey(icon.replace("$index", "01"));
+        final String activeIcon = ConversionUtils.getCanonicalAssetKey(icon.replace("$index", "02"));
+        
+        Element image = new ImageBuilder("sysmessage.id" + counter++){{
+            filename(normalIcon);
+            //marginLeft("4px");
+            visibleToMouse(true);
+            visible(false);
+            onHoverEffect(new HoverEffectBuilder("imageOverlay"){{
+                // using filename leads to an NPE, no idea why...
+                getAttributes().setAttribute("filename", hoverIcon);
+                post(true);
+            }});
+            onActiveEffect(new EffectBuilder("imageOverlayPulsate"){{
+                getAttributes().setAttribute("filename", activeIcon);
+                post(true);
+            }});
+            onShowEffect(new EffectBuilder("move"){{
+                getAttributes().setAttribute("mode", "in");
+                getAttributes().setAttribute("direction", "right");
+                length(1000);
+                startDelay(0);
+            }});
+            set("text", text);
+            controller(SystemMessageControl.class.getName());
+            interactOnClick("showMessage()");
+        }}.build(nifty, nifty.getScreen("hud"), nifty.getScreen("hud").findElementById("systemMessages"));
+        image.show();
+        
+        syncActiveEffects();
+    }
+    
+    @Override
+    public void update(float tpf) {
+        Element systemMessages = nifty.getScreen("hud").findElementById("systemMessages");
+        if (systemMessages != null) {
+            for(Element child : systemMessages.getChildren()) {
+                SystemMessageControl control = child.getControl(SystemMessageControl.class);
+                if (control != null && System.currentTimeMillis() - control.getCreatedAt() > lifeTime) {
+                    child.markForRemoval();
+                }
+            }
+        }
+    }
+    
+    /**
+     * Used to sync the effect on active messages.
+     * Otherwise all messages pulsate differently, which looks odd.
+     */
+    public void syncActiveEffects() {
+        Element systemMessages = nifty.getScreen("hud").findElementById("systemMessages");
+        if (systemMessages != null) {
+            for(Element child : systemMessages.getChildren()) {
+                SystemMessageControl control = child.getControl(SystemMessageControl.class);
+                if (control != null && control.isUnread()) {
+                    child.startEffect(EffectEventId.onActive);
+                }
+            }
+        }
+    }
+    
+    @Override
+    public boolean isPauseable() {
+        return true;
+    }
+}

--- a/src/toniarts/openkeeper/game/trigger/TriggerControl.java
+++ b/src/toniarts/openkeeper/game/trigger/TriggerControl.java
@@ -34,6 +34,7 @@ import toniarts.openkeeper.game.player.PlayerCameraRotateControl;
 import toniarts.openkeeper.game.state.GameState;
 import toniarts.openkeeper.game.state.PlayerState;
 import toniarts.openkeeper.game.state.SoundState;
+import toniarts.openkeeper.game.state.SystemMessageState;
 import toniarts.openkeeper.game.trigger.creature.CreatureTriggerState;
 import toniarts.openkeeper.tools.convert.ConversionUtils;
 import toniarts.openkeeper.tools.convert.map.KwdFile;
@@ -311,7 +312,7 @@ public class TriggerControl extends Control {
             case PLAY_SPEECH:
                 int speechId = trigger.getUserData("speechId", int.class);
                 stateManager.getState(SoundState.class).attachSpeech(speechId);
-
+                stateManager.getState(SystemMessageState.class).addMessage(SystemMessageState.MessageType.INFO, String.format("${level.%d}", speechId - 1));
                 int pathId = trigger.getUserData("pathId", int.class);
                 // text show when Cinematic camera by pathId
                 boolean introduction = trigger.getUserData("introduction", short.class) != 0;

--- a/src/toniarts/openkeeper/gui/nifty/SystemMessageControl.java
+++ b/src/toniarts/openkeeper/gui/nifty/SystemMessageControl.java
@@ -44,6 +44,8 @@ public class SystemMessageControl extends AbstractController {
         this.text = parameter.get("text");
         this.element = element;
         this.nifty = nifty;
+        // sync effects on adding messages
+        syncActiveEffects();
     }
 
     @Override

--- a/src/toniarts/openkeeper/gui/nifty/SystemMessageControl.java
+++ b/src/toniarts/openkeeper/gui/nifty/SystemMessageControl.java
@@ -35,13 +35,13 @@ public class SystemMessageControl extends AbstractController {
     private Nifty nifty;
     private Element element;
     private boolean unread = true;
-    private String textId = "";
+    private String text = "";
     private Object object = null;
     private final Long createdAt = System.currentTimeMillis();
 
     @Override
     public void bind(Nifty nifty, Screen screen, Element element, Parameters parameter) {
-        this.textId = parameter.get("text");
+        this.text = parameter.get("text");
         this.element = element;
         this.nifty = nifty;
     }
@@ -76,7 +76,7 @@ public class SystemMessageControl extends AbstractController {
         Element infoBox = this.nifty.getScreen("hud").findElementById("infoBox");
         if (infoBox != null) {
             infoBox.setVisible(true);
-            infoBox.findNiftyControl("messageText", Label.class).setText(this.textId);
+            infoBox.findNiftyControl("messageText", Label.class).setText(this.text);
             // update layout otherwise the scrollbar isn't correct
             infoBox.layoutElements();
         }

--- a/src/toniarts/openkeeper/gui/nifty/SystemMessageControl.java
+++ b/src/toniarts/openkeeper/gui/nifty/SystemMessageControl.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2014-2016 OpenKeeper
+ *
+ * OpenKeeper is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * OpenKeeper is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenKeeper.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package toniarts.openkeeper.gui.nifty;
+
+import de.lessvoid.nifty.Nifty;
+import de.lessvoid.nifty.NiftyEventSubscriber;
+import de.lessvoid.nifty.controls.AbstractController;
+import de.lessvoid.nifty.controls.Label;
+import de.lessvoid.nifty.controls.Parameters;
+import de.lessvoid.nifty.effects.EffectEventId;
+import de.lessvoid.nifty.elements.Element;
+import de.lessvoid.nifty.elements.events.NiftyMouseSecondaryClickedEvent;
+import de.lessvoid.nifty.input.NiftyInputEvent;
+import de.lessvoid.nifty.screen.Screen;
+
+/**
+ *
+ * @author ufdada
+ */
+public class SystemMessageControl extends AbstractController {
+    private Nifty nifty;
+    private Element element;
+    private boolean unread = true;
+    private String textId = "";
+    private Object object = null;
+    private final Long createdAt = System.currentTimeMillis();
+
+    @Override
+    public void bind(Nifty nifty, Screen screen, Element element, Parameters parameter) {
+        this.textId = parameter.get("text");
+        this.element = element;
+        this.nifty = nifty;
+    }
+
+    @Override
+    public void onStartScreen() {
+    }
+
+    @Override
+    public boolean inputEvent(NiftyInputEvent inputEvent) {
+        return false;
+    }
+
+    /**
+     * Set the message as read
+     * @param read 
+     */
+    public void setRead(boolean read) {
+        this.unread = !read;
+        if (read) {
+            this.element.stopEffect(EffectEventId.onActive);
+        } else {
+            syncActiveEffects();
+        }
+    }
+
+    /**
+     * Show a message in an info box
+     */
+    public void showMessage() {
+        this.setRead(this.unread);
+        Element infoBox = this.nifty.getScreen("hud").findElementById("infoBox");
+        if (infoBox != null) {
+            infoBox.setVisible(true);
+            infoBox.findNiftyControl("messageText", Label.class).setText(this.textId);
+            // update layout otherwise the scrollbar isn't correct
+            infoBox.layoutElements();
+        }
+    }
+
+    /**
+     * Remove a message from the message queue
+     */
+    public void dismissMessage() {
+        this.element.markForRemoval();
+    }
+
+    @NiftyEventSubscriber(pattern="sysmessage.*")
+    public void onClickedSecondaryMouse(String id, NiftyMouseSecondaryClickedEvent event) {
+        if (id.equals(this.element.getId())) {
+            this.dismissMessage();
+        }
+    }
+
+    /**
+     * Used to sync the effect on active messages.
+     * Otherwise all messages pulsate differently, which looks odd.
+     */
+    public void syncActiveEffects() {
+        Element systemMessages = nifty.getScreen("hud").findElementById("systemMessages");
+        if (systemMessages != null) {
+            for(Element child : systemMessages.getChildren()) {
+                SystemMessageControl control = child.getControl(SystemMessageControl.class);
+                if (control != null && control.unread) {
+                    child.startEffect(EffectEventId.onActive);
+                }
+            }
+        }
+    }
+
+    /**
+     * @return the time this message was created
+     */
+    public long getCreatedAt() {
+        return this.createdAt;
+    }
+
+    /**
+     * @return true if system message unread by the user
+     */
+    public boolean isUnread() {
+        return this.unread;
+    }
+}

--- a/src/toniarts/openkeeper/gui/nifty/SystemMessageControl.java
+++ b/src/toniarts/openkeeper/gui/nifty/SystemMessageControl.java
@@ -72,7 +72,7 @@ public class SystemMessageControl extends AbstractController {
      * Show a message in an info box
      */
     public void showMessage() {
-        this.setRead(this.unread);
+        this.setRead(true);
         Element infoBox = this.nifty.getScreen("hud").findElementById("infoBox");
         if (infoBox != null) {
             infoBox.setVisible(true);

--- a/src/toniarts/openkeeper/gui/nifty/message/MessageBoxControl.java
+++ b/src/toniarts/openkeeper/gui/nifty/message/MessageBoxControl.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2014-2016 OpenKeeper
+ *
+ * OpenKeeper is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * OpenKeeper is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenKeeper.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package toniarts.openkeeper.gui.nifty.message;
+
+import de.lessvoid.nifty.Nifty;
+import de.lessvoid.nifty.builder.ControlBuilder;
+import de.lessvoid.nifty.controls.AbstractController;
+import de.lessvoid.nifty.controls.Label;
+import de.lessvoid.nifty.controls.Parameters;
+import de.lessvoid.nifty.elements.Element;
+import de.lessvoid.nifty.input.NiftyInputEvent;
+import de.lessvoid.nifty.screen.Screen;
+
+/**
+ *
+ * @author ufdada
+ */
+public class MessageBoxControl extends AbstractController {
+    private Nifty nifty;
+    private Screen hud;
+    private Element element;
+    private Element buttonPanel;
+    private SystemMessageControl systemMessage;
+
+    private enum ButtonType {
+        EXIT,
+        TICK,
+        GOTO
+    }
+
+    @Override
+    public void bind(Nifty nifty, Screen screen, Element element, Parameters parameter) {
+        this.nifty = nifty;
+        this.hud = nifty.getScreen("hud");
+        this.element = element;
+        this.buttonPanel = element.findElementById("buttonPanel");
+    }
+
+    @Override
+    public void onStartScreen() {
+    }
+
+    @Override
+    public boolean inputEvent(NiftyInputEvent inputEvent) {
+        return false;
+    }
+
+    public void focusElement() {
+        // TODO
+    }
+
+    public void dismissMessage() {
+        this.systemMessage.dismissMessage();
+        this.hide();
+    }
+    
+    public void closeMessage() {
+        this.hide();
+    }
+
+    public void show() {
+        this.element.show();
+    }
+
+    public void hide() {
+        this.systemMessage = null;
+        this.element.hide();
+    }
+
+    private void showMessageBox(final String text) {
+        this.setText(text);
+
+        this.cleanButtonPanel();
+
+        this.show();
+    }
+    
+    public void showMessage(final String text) {
+        this.showMessageBox(text);
+        this.addButton(ButtonType.TICK, "closeMessage()");
+    }
+
+    public void showSystemMessage(final SystemMessageControl systemMessage, final String text) {
+        this.systemMessage = systemMessage;
+        
+        this.showMessageBox(text);
+        this.addButton(ButtonType.EXIT, "dismissMessage()");
+        this.addButton(ButtonType.TICK, "closeMessage()");
+    }
+
+    public void showFocusMessage(final SystemMessageControl systemMessage, final String text) {
+        this.showSystemMessage(systemMessage, text);
+
+        this.addButton(ButtonType.GOTO, "focusElement()");
+    }
+
+    public void setText(final String text) {
+        this.element.findNiftyControl("messageText", Label.class).setText(text);
+        // update layout otherwise the scrollbar isn't correct
+        this.element.layoutElements();
+    }
+
+    private void addButton(final ButtonType button, final String onClick) {
+        String image = String.format("Textures/GUI/Tabs/Messages/mt-%s-$index.png", button.toString().toLowerCase());
+        new ControlBuilder("messageButton"){{
+            parameter("image", image.replace("$index", "00"));
+            parameter("hoverImage", image.replace("$index", "01"));
+            parameter("activeImage", image.replace("$index", "02"));
+            parameter("click", onClick);
+        }}.build(this.nifty, this.hud, this.buttonPanel);
+    }
+
+    private void cleanButtonPanel() {
+        this.buttonPanel.getChildren().forEach((child)->{
+            child.markForRemoval();
+        });
+    }
+}

--- a/src/toniarts/openkeeper/gui/nifty/message/MessageBoxControl.java
+++ b/src/toniarts/openkeeper/gui/nifty/message/MessageBoxControl.java
@@ -64,7 +64,9 @@ public class MessageBoxControl extends AbstractController {
     }
 
     public void dismissMessage() {
-        this.systemMessage.dismissMessage();
+        if (this.systemMessage != null) {
+            this.systemMessage.dismissMessage();
+        }
         this.hide();
     }
     
@@ -89,11 +91,22 @@ public class MessageBoxControl extends AbstractController {
         this.show();
     }
     
+    /**
+     * Shows a message box with text
+     * 
+     * @param text 
+     */
     public void showMessage(final String text) {
         this.showMessageBox(text);
         this.addButton(ButtonType.TICK, "closeMessage()");
     }
 
+    /**
+     * Shows a removeable system message
+     * 
+     * @param systemMessage The control of the system message
+     * @param text 
+     */
     public void showSystemMessage(final SystemMessageControl systemMessage, final String text) {
         this.systemMessage = systemMessage;
         
@@ -102,12 +115,21 @@ public class MessageBoxControl extends AbstractController {
         this.addButton(ButtonType.TICK, "closeMessage()");
     }
 
+    /**
+     * TODO
+     * @param systemMessage
+     * @param text 
+     */
     public void showFocusMessage(final SystemMessageControl systemMessage, final String text) {
         this.showSystemMessage(systemMessage, text);
 
         this.addButton(ButtonType.GOTO, "focusElement()");
     }
 
+    /**
+     * Sets the text of the message box
+     * @param text 
+     */
     public void setText(final String text) {
         this.element.findNiftyControl("messageText", Label.class).setText(text);
         // update layout otherwise the scrollbar isn't correct

--- a/src/toniarts/openkeeper/gui/nifty/message/SystemMessageControl.java
+++ b/src/toniarts/openkeeper/gui/nifty/message/SystemMessageControl.java
@@ -86,13 +86,6 @@ public class SystemMessageControl extends AbstractController {
         this.element.markForRemoval();
     }
 
-    @NiftyEventSubscriber(pattern="sysmessage.*")
-    public void onClickedSecondaryMouse(String id, NiftyMouseSecondaryClickedEvent event) {
-        if (id.equals(this.element.getId())) {
-            this.dismissMessage();
-        }
-    }
-
     /**
      * Used to sync the effect on active messages.
      * Otherwise all messages pulsate differently, which looks odd.

--- a/src/toniarts/openkeeper/gui/nifty/message/SystemMessageControl.java
+++ b/src/toniarts/openkeeper/gui/nifty/message/SystemMessageControl.java
@@ -19,7 +19,6 @@ package toniarts.openkeeper.gui.nifty.message;
 import de.lessvoid.nifty.Nifty;
 import de.lessvoid.nifty.NiftyEventSubscriber;
 import de.lessvoid.nifty.controls.AbstractController;
-import de.lessvoid.nifty.controls.Label;
 import de.lessvoid.nifty.controls.Parameters;
 import de.lessvoid.nifty.effects.EffectEventId;
 import de.lessvoid.nifty.elements.Element;
@@ -122,5 +121,12 @@ public class SystemMessageControl extends AbstractController {
      */
     public boolean isUnread() {
         return this.unread;
+    }
+
+    /**
+     * @return text of the system message
+     */
+    public String getText() {
+        return this.text;
     }
 }

--- a/src/toniarts/openkeeper/gui/nifty/message/SystemMessageControl.java
+++ b/src/toniarts/openkeeper/gui/nifty/message/SystemMessageControl.java
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenKeeper.  If not, see <http://www.gnu.org/licenses/>.
  */
-package toniarts.openkeeper.gui.nifty;
+package toniarts.openkeeper.gui.nifty.message;
 
 import de.lessvoid.nifty.Nifty;
 import de.lessvoid.nifty.NiftyEventSubscriber;
@@ -38,12 +38,14 @@ public class SystemMessageControl extends AbstractController {
     private String text = "";
     private Object object = null;
     private final Long createdAt = System.currentTimeMillis();
+    private Screen hud;
 
     @Override
     public void bind(Nifty nifty, Screen screen, Element element, Parameters parameter) {
         this.text = parameter.get("text");
         this.element = element;
         this.nifty = nifty;
+        this.hud = this.nifty.getScreen("hud");
         // sync effects on adding messages
         syncActiveEffects();
     }
@@ -75,13 +77,7 @@ public class SystemMessageControl extends AbstractController {
      */
     public void showMessage() {
         this.setRead(true);
-        Element infoBox = this.nifty.getScreen("hud").findElementById("infoBox");
-        if (infoBox != null) {
-            infoBox.setVisible(true);
-            infoBox.findNiftyControl("messageText", Label.class).setText(this.text);
-            // update layout otherwise the scrollbar isn't correct
-            infoBox.layoutElements();
-        }
+        hud.findControl("messageBox", MessageBoxControl.class).showSystemMessage(this, text);
     }
 
     /**


### PR DESCRIPTION
Resolves #220 

This is a basic implementation of the system messages. Currently it only shows the scripted (triggered) speeches of the mentor. I also using now a smaller scrollbar, which fits the theme better than the big one of the main menu.

![main1](https://cloud.githubusercontent.com/assets/3787188/18030251/801b83aa-6caf-11e6-95f2-2d5b07d24f01.png)

I found several things that should be fixed to make this work flawlessly:

1. The player interaction needs to be revamped. The gui recognition is more a guess than a correct determination (it tries to figure out the viewport). Therefore the cursor isn't correct and a implementation of the tooltip doesn't make sense because it would overwritten immediately.
2. Focusing things isn't implemented right now (like the first creature appearance which can be overwritten like in the first level)