### PR TITLE
Creature messages

### DIFF
--- a/src/toniarts/openkeeper/game/player/PlayerTriggerControl.java
+++ b/src/toniarts/openkeeper/game/player/PlayerTriggerControl.java
@@ -17,6 +17,8 @@
 package toniarts.openkeeper.game.player;
 
 import com.jme3.app.state.AppStateManager;
+import com.jme3.cinematic.events.CinematicEvent;
+import com.jme3.cinematic.events.CinematicEventListener;
 import java.awt.Point;
 import java.util.Set;
 import java.util.logging.Level;
@@ -373,7 +375,7 @@ public class PlayerTriggerControl extends TriggerControl {
             case PLAY_SPEECH: // Info part
                 if (playerId == playerState.getPlayerId()) {
                     int speechId = trigger.getUserData("speechId", int.class);
-                    stateManager.getState(SoundState.class).attachSpeech(speechId);
+                    stateManager.getState(SoundState.class).attachLevelSpeech(speechId);
                     stateManager.getState(SystemMessageState.class).addMessage(SystemMessageState.MessageType.INFO, String.format("${level.%d}", speechId - 1));
                     int pathId = trigger.getUserData("pathId", int.class);
                     // text show when Cinematic camera by pathId

--- a/src/toniarts/openkeeper/game/state/SoundState.java
+++ b/src/toniarts/openkeeper/game/state/SoundState.java
@@ -38,7 +38,7 @@ public class SoundState extends AbstractPauseAwareState {
     private AppStateManager stateManager;
     private AudioNode speech = null;
     private AudioNode background = null;
-    private final Queue<Integer> speechQueue = new LinkedList<>();
+    private final Queue<String> speechQueue = new LinkedList<>();
     private static final Logger logger = Logger.getLogger(SoundState.class.getName());
 
     public SoundState() {
@@ -61,14 +61,30 @@ public class SoundState extends AbstractPauseAwareState {
         return false;
     }
 
-    public void attachSpeech(int speechId) {
-        speechQueue.add(speechId);
+    /**
+     * Plays mentor speeches for the current level
+     *
+     * @param speechId
+     */
+    public void attachLevelSpeech(int speechId) {
+        String file = String.format("Sounds/%s/lvlspe%02d.mp2", stateManager.getState(GameState.class).getLevelData().getGameLevel().getSpeechStr().toLowerCase(), speechId);
+        speechQueue.add(file);
     }
 
-    private void playSpeech(int speechId) {
-        String file = String.format("Sounds/%s/lvlspe%02d.mp2", stateManager.getState(GameState.class).getLevelData().getGameLevel().getSpeechStr().toLowerCase(), speechId);
+    /**
+     * Plays general mentor speeches
+     *
+     * @param audioFile Name of the audio file in the speech_mentor folder,
+     * without extension!
+     */
+    public void attachMentorSpeech(String audioFile) {
+        String file = String.format("Sounds/speech_mentor/%s.mp2", audioFile);
+        speechQueue.add(file);
+    }
+
+    private void playSpeech(String file) {
         speech = new AudioNode(app.getAssetManager(), file, false);
-        if (background == null) {
+        if (speech == null) {
             logger.log(Level.WARNING, "Audio file {0} not found", file);
             return;
         }
@@ -151,8 +167,8 @@ public class SoundState extends AbstractPauseAwareState {
 
         if (!speechQueue.isEmpty()) {
             if (speech == null || speech.getStatus() == AudioSource.Status.Stopped) {
-                Integer speechId = speechQueue.poll();
-                playSpeech(speechId);
+                String speechFile = speechQueue.poll();
+                playSpeech(speechFile);
             }
         }
 

--- a/src/toniarts/openkeeper/view/PlayerCameraState.java
+++ b/src/toniarts/openkeeper/view/PlayerCameraState.java
@@ -212,6 +212,7 @@ public class PlayerCameraState extends AbstractPauseAwareState implements Action
             @Override
             public void onPlay(CinematicEvent cinematic) {
                 stateManager.getState(PlayerState.class).setTransitionEnd(false);
+                stateManager.getState(PlayerState.class).setWideScreen(true);
                 inputManager.setCursorVisible(false);
                 PlayerCameraState.this.cameraStore();
             }
@@ -223,6 +224,7 @@ public class PlayerCameraState extends AbstractPauseAwareState implements Action
             @Override
             public void onStop(CinematicEvent cinematic) {
                 stateManager.getState(PlayerState.class).setTransitionEnd(true);
+                stateManager.getState(PlayerState.class).setWideScreen(false);
                 inputManager.setCursorVisible(true);
                 PlayerCameraState.this.cameraRestore();
             }

--- a/src/toniarts/openkeeper/world/WorldState.java
+++ b/src/toniarts/openkeeper/world/WorldState.java
@@ -199,7 +199,7 @@ public abstract class WorldState extends AbstractAppState {
                                 message = String.format("${level.%d}", creatureIntroOveride.getValue() - 1);
                                 stateManager.getState(SoundState.class).attachLevelSpeech(creatureIntroOveride.getValue());
 
-                                stateManager.getState(PlayerState.class).setText(creatureIntroOveride.getValue(), true);
+                                stateManager.getState(PlayerState.class).setText(creatureIntroOveride.getValue(), true, 0);
                             }
                         }
 


### PR DESCRIPTION
This add system messages when a creature enters for the first time the dungeon.

If the introduction override is set, it will display a custom message and play the corresponding mentor speech (like for the goblin in level 1).