### PR TITLE
Clean asset folders before converting

### DIFF
--- a/src/toniarts/openkeeper/game/state/MainMenuState.java
+++ b/src/toniarts/openkeeper/game/state/MainMenuState.java
@@ -54,15 +54,14 @@ import toniarts.openkeeper.game.network.message.MessageChat;
 import toniarts.openkeeper.game.state.loading.SingleBarLoadingState;
 import toniarts.openkeeper.gui.CursorFactory;
 import toniarts.openkeeper.tools.convert.AssetsConverter;
-import static toniarts.openkeeper.tools.convert.AssetsConverter.MAP_THUMBNAILS_FOLDER;
 import toniarts.openkeeper.tools.convert.ConversionUtils;
 import toniarts.openkeeper.tools.convert.map.KwdFile;
 import toniarts.openkeeper.tools.convert.map.Player;
 import toniarts.openkeeper.utils.AssetUtils;
 import toniarts.openkeeper.utils.PathUtils;
+import toniarts.openkeeper.utils.WorldUtils;
 import toniarts.openkeeper.video.MovieState;
 import toniarts.openkeeper.world.MapLoader;
-import toniarts.openkeeper.utils.WorldUtils;
 import toniarts.openkeeper.world.effect.EffectManagerState;
 import toniarts.openkeeper.world.object.ObjectLoader;
 import toniarts.openkeeper.world.room.control.FrontEndLevelControl;
@@ -522,12 +521,12 @@ public class MainMenuState extends AbstractAppState {
      */
     protected String getMapThumbnail(KwdFile map) {
         // See if the map thumbnail exist, otherwise create one
-        String asset = "Textures/Thumbnails/" + ConversionUtils.stripFileName(map.getGameLevel().getName()) + ".png";
+        String asset = AssetsConverter.MAP_THUMBNAILS_FOLDER + File.separator + ConversionUtils.stripFileName(map.getGameLevel().getName()) + ".png";
         if (assetManager.locateAsset(new TextureKey(asset)) == null) {
 
             // Generate
             try {
-                AssetsConverter.genererateMapThumbnail(map, AssetsConverter.getAssetsFolder() + MAP_THUMBNAILS_FOLDER + File.separator);
+                AssetsConverter.genererateMapThumbnail(map, AssetsConverter.getAssetsFolder() + AssetsConverter.MAP_THUMBNAILS_FOLDER + File.separator);
             } catch (Exception e) {
                 logger.log(java.util.logging.Level.WARNING, "Failed to generate map file out of {0}!", map);
                 asset = "Textures/Unique_NoTextureName.png";

--- a/src/toniarts/openkeeper/tools/convert/AssetsConverter.java
+++ b/src/toniarts/openkeeper/tools/convert/AssetsConverter.java
@@ -100,7 +100,7 @@ public abstract class AssetsConverter {
         PATHS(4),
         HI_SCORES(2),
         FONTS(3),
-        MAP_THUMBNAILS(2);
+        MAP_THUMBNAILS(3);
 
         private ConvertProcess(int version) {
             this.version = version;

--- a/src/toniarts/openkeeper/tools/convert/AssetsConverter.java
+++ b/src/toniarts/openkeeper/tools/convert/AssetsConverter.java
@@ -145,7 +145,7 @@ public abstract class AssetsConverter {
     public static final String TEXTURES_FOLDER = "Textures";
     public static final String SPRITES_FOLDER = "Sprites";
     public static final String MAP_THUMBNAILS_FOLDER = "Thumbnails";
-    public static final String INTERFACE_FOLDER = "Interface" + File.separator;
+    private static final String INTERFACE_FOLDER = "Interface" + File.separator;
     public static final String MOUSE_CURSORS_FOLDER = INTERFACE_FOLDER + "Cursors";
     public static final String FONTS_FOLDER = INTERFACE_FOLDER + "Fonts";
     public static final String TEXTS_FOLDER = INTERFACE_FOLDER + "Texts";

--- a/src/toniarts/openkeeper/tools/convert/AssetsConverter.java
+++ b/src/toniarts/openkeeper/tools/convert/AssetsConverter.java
@@ -70,6 +70,7 @@ import toniarts.openkeeper.tools.convert.str.StrFile;
 import toniarts.openkeeper.tools.convert.textures.enginetextures.EngineTexturesFile;
 import toniarts.openkeeper.tools.convert.textures.loadingscreens.LoadingScreenFile;
 import toniarts.openkeeper.tools.convert.wad.WadFile;
+import toniarts.openkeeper.utils.AssetUtils;
 import toniarts.openkeeper.utils.PathUtils;
 import toniarts.openkeeper.world.MapThumbnailGenerator;
 
@@ -142,11 +143,12 @@ public abstract class AssetsConverter {
     public static final String MATERIALS_FOLDER = "Materials";
     public static final String MODELS_FOLDER = "Models";
     public static final String TEXTURES_FOLDER = "Textures";
-    public static final String MAP_THUMBNAILS_FOLDER = TEXTURES_FOLDER + File.separator + "Thumbnails";
-    public static final String MOUSE_CURSORS_FOLDER = "Interface" + File.separator + "Cursors";
-    public static final String FONTS_FOLDER = "Interface" + File.separator + "Fonts";
-    public static final String TEXTS_FOLDER = "Interface" + File.separator + "Texts";
-    public static final String PATHS_FOLDER = "Interface" + File.separator + "Paths";
+    public static final String MAP_THUMBNAILS_FOLDER = "Thumbnails";
+    public static final String INTERFACE_FOLDER = "Interface" + File.separator;
+    public static final String MOUSE_CURSORS_FOLDER = INTERFACE_FOLDER + "Cursors";
+    public static final String FONTS_FOLDER = INTERFACE_FOLDER + "Fonts";
+    public static final String TEXTS_FOLDER = INTERFACE_FOLDER + "Texts";
+    public static final String PATHS_FOLDER = INTERFACE_FOLDER + "Paths";
 
     private static final Logger logger = Logger.getLogger(AssetsConverter.class.getName());
 
@@ -245,6 +247,7 @@ public abstract class AssetsConverter {
         }
         logger.log(Level.INFO, "Extracting textures to: {0}", destination);
         updateStatus(null, null, ConvertProcess.TEXTURES);
+        AssetUtils.deleteFolder(new File(destination));
         EngineTexturesFile etFile = getEngineTexturesFile(dungeonKeeperFolder);
         Pattern pattern = Pattern.compile("(?<name>\\w+)MM(?<mipmaplevel>\\d{1})");
         WadFile frontEnd;
@@ -305,9 +308,12 @@ public abstract class AssetsConverter {
         }
         logger.log(Level.INFO, "Extracting models to: {0}", destination);
         updateStatus(null, null, ConvertProcess.MODELS);
+        AssetUtils.deleteFolder(new File(destination));
 
         // Create the materials folder or else the material file saving fails
-        new File(getAssetsFolder().concat(AssetsConverter.MATERIALS_FOLDER)).mkdirs();
+        File materialFolder = new File(getAssetsFolder().concat(AssetsConverter.MATERIALS_FOLDER));
+        AssetUtils.deleteFolder(materialFolder);
+        materialFolder.mkdirs();
 
         // Get the engine textures catalog
         EngineTexturesFile engineTexturesFile = getEngineTexturesFile(dungeonKeeperFolder);
@@ -417,6 +423,7 @@ public abstract class AssetsConverter {
         }
         logger.log(Level.INFO, "Extracting mouse cursors to: {0}", destination);
         updateStatus(null, null, ConvertProcess.MOUSE_CURSORS);
+        AssetUtils.deleteFolder(new File(destination));
 
         //Mouse cursors are PNG files in the Sprite.WAD
         WadFile wadFile = new WadFile(new File(dungeonKeeperFolder + PathUtils.DKII_DATA_FOLDER + "Sprite.WAD"));
@@ -456,6 +463,7 @@ public abstract class AssetsConverter {
         }
         logger.log(Level.INFO, "Extracting sounds to: {0}", destination);
         updateStatus(null, null, ConvertProcess.MUSIC_AND_SOUNDS);
+        AssetUtils.deleteFolder(new File(destination));
         String dataDirectory = PathUtils.DKII_SFX_FOLDER;
 
         //Find all the sound files
@@ -553,6 +561,7 @@ public abstract class AssetsConverter {
         }
         logger.log(Level.INFO, "Extracting texts to: {0}", destination);
         updateStatus(null, null, ConvertProcess.INTERFACE_TEXTS);
+        AssetUtils.deleteFolder(new File(destination));
         String dataDirectory = dungeonKeeperFolder + PathUtils.DKII_TEXT_DEFAULT_FOLDER;
 
         //Find all the STR files
@@ -655,6 +664,7 @@ public abstract class AssetsConverter {
         }
         logger.log(Level.INFO, "Extracting paths to: {0}", destination);
         updateStatus(null, null, ConvertProcess.PATHS);
+        AssetUtils.deleteFolder(new File(destination));
 
         //Paths are in the data folder, access the packed file
         WadFile wad = new WadFile(new File(dungeonKeeperFolder + PathUtils.DKII_DATA_FOLDER + "Paths.WAD"));
@@ -754,6 +764,7 @@ public abstract class AssetsConverter {
         }
         logger.log(Level.INFO, "Extracting fonts to: {0}", destination);
         updateStatus(null, null, ConvertProcess.FONTS);
+        AssetUtils.deleteFolder(new File(destination));
 
         try {
 
@@ -840,6 +851,10 @@ public abstract class AssetsConverter {
         }
         logger.log(Level.INFO, "Generating map thumbnails to: {0}", destination);
         updateStatus(null, null, ConvertProcess.MAP_THUMBNAILS);
+        File destFolder = new File(destination);
+        AssetUtils.deleteFolder(destFolder);
+        // Make sure it exists
+        destFolder.mkdirs();
         try {
 
             // Get the skirmish/mp maps

--- a/src/toniarts/openkeeper/tools/convert/AssetsConverter.java
+++ b/src/toniarts/openkeeper/tools/convert/AssetsConverter.java
@@ -94,7 +94,7 @@ public abstract class AssetsConverter {
 
         TEXTURES(4),
         MODELS(6),
-        MOUSE_CURSORS(3),
+        MOUSE_CURSORS(4),
         MUSIC_AND_SOUNDS(3),
         INTERFACE_TEXTS(2),
         PATHS(4),
@@ -143,6 +143,7 @@ public abstract class AssetsConverter {
     public static final String MATERIALS_FOLDER = "Materials";
     public static final String MODELS_FOLDER = "Models";
     public static final String TEXTURES_FOLDER = "Textures";
+    public static final String SPRITES_FOLDER = "Sprites";
     public static final String MAP_THUMBNAILS_FOLDER = "Thumbnails";
     public static final String INTERFACE_FOLDER = "Interface" + File.separator;
     public static final String MOUSE_CURSORS_FOLDER = INTERFACE_FOLDER + "Cursors";
@@ -429,7 +430,8 @@ public abstract class AssetsConverter {
         WadFile wadFile = new WadFile(new File(dungeonKeeperFolder + PathUtils.DKII_DATA_FOLDER + "Sprite.WAD"));
         int i = 0;
         int total = wadFile.getWadFileEntryCount();
-        File destinationFolder = new File(getAssetsFolder().concat(TEXTURES_FOLDER).concat(File.separator).concat("Sprites/"));
+        File destinationFolder = new File(getAssetsFolder().concat(SPRITES_FOLDER).concat(File.separator));
+        AssetUtils.deleteFolder(destinationFolder);
         destinationFolder.mkdirs();
 
         for (String fileName : wadFile.getWadFileEntries()) {

--- a/src/toniarts/openkeeper/utils/AssetUtils.java
+++ b/src/toniarts/openkeeper/utils/AssetUtils.java
@@ -611,4 +611,37 @@ public class AssetUtils {
 
         return new Node();
     }
+
+    /**
+     * Deletes a file or a folder
+     *
+     * @param file
+     * @return true if the file or folder was deleted
+     */
+    public static boolean deleteFolder(final File file) {
+        File[] fileList = null;
+
+        if (file == null) {
+            return false;
+        }
+
+        if (file.isFile()) {
+            return file.delete();
+        }
+
+        if (!file.isDirectory()) {
+            return false;
+        }
+
+        fileList = file.listFiles();
+        if (fileList != null && fileList.length > 0) {
+            for (File f : fileList) {
+                if (!deleteFolder(f)) {
+                    return false;
+                }
+            }
+        }
+
+        return file.delete();
+    }
 }

--- a/src/toniarts/openkeeper/utils/AssetUtils.java
+++ b/src/toniarts/openkeeper/utils/AssetUtils.java
@@ -303,6 +303,7 @@ public class AssetUtils {
     }
 
     private static Texture createArtResourceTexture(ArtResource resource, AssetManager assetManager) throws IOException {
+        String assetFolder = AssetsConverter.TEXTURES_FOLDER + File.separator;
 
         if (resource.getFlags().contains(ArtResource.ArtResourceFlag.ANIMATING_TEXTURE)) {
 
@@ -314,7 +315,7 @@ public class AssetUtils {
             }
 
             // Get the first frame, the frames need to be same size
-            BufferedImage img = ImageIO.read(assetManager.locateAsset(new AssetKey(ConversionUtils.getCanonicalAssetKey("Textures/" + resource.getName() + "0.png"))).openStream());
+            BufferedImage img = ImageIO.read(assetManager.locateAsset(new AssetKey(ConversionUtils.getCanonicalAssetKey(assetFolder + resource.getName() + "0.png"))).openStream());
 
             // Create image big enough to fit all the frames
             int frames = resource.getData("frames");
@@ -323,7 +324,7 @@ public class AssetUtils {
             Graphics2D g = text.createGraphics();
             g.drawImage(img, rop, 0, 0);
             for (int x = 1; x < frames; x++) {
-                AssetInfo asset = assetManager.locateAsset(new AssetKey(ConversionUtils.getCanonicalAssetKey("Textures/" + resource.getName() + x + ".png")));
+                AssetInfo asset = assetManager.locateAsset(new AssetKey(ConversionUtils.getCanonicalAssetKey(assetFolder + resource.getName() + x + ".png")));
                 if (asset != null) {
                     img = ImageIO.read(asset.openStream());
                 } else {
@@ -339,9 +340,13 @@ public class AssetUtils {
             Texture tex = new Texture2D(loader.load(text, false));
             return tex;
         } else {
+            if (resource.getType().equals(ArtResource.ArtResourceType.SPRITE) && resource.getData("width").intValue() > 1) {
+                // only the unused sprites have a size of bigger than one
+                assetFolder = AssetsConverter.SPRITES_FOLDER + File.separator;
+            }
 
             // A regular texture
-            TextureKey key = new TextureKey(ConversionUtils.getCanonicalAssetKey("Textures/" + resource.getName() + ".png"), false);
+            TextureKey key = new TextureKey(ConversionUtils.getCanonicalAssetKey(assetFolder + resource.getName() + ".png"), false);
             return assetManager.loadTexture(key);
         }
     }


### PR DESCRIPTION
This clean the folders where the assets are stored before a new conversion is happening. This should avoid having the need to manually remove the assets.

Since we don't really respect custom models / textures (because they may be overwritten in the conversion process anyway) yet i see it less problematic right now.