### PR TITLE
Movie unlock

### DIFF
--- a/src/toniarts/openkeeper/game/data/Level.java
+++ b/src/toniarts/openkeeper/game/data/Level.java
@@ -19,6 +19,7 @@ package toniarts.openkeeper.game.data;
 import java.io.File;
 import java.io.IOException;
 import java.util.logging.Logger;
+import javax.annotation.Nullable;
 import toniarts.openkeeper.Main;
 import toniarts.openkeeper.tools.convert.ConversionUtils;
 import toniarts.openkeeper.tools.convert.map.KwdFile;
@@ -35,9 +36,14 @@ public class Level extends GeneralLevel {
     }
     private final LevelType type;
     private final int level;
-    private final String variation;
+    private String variation = null;
 
-    public Level(LevelType type, int level, String variation) {
+    public Level(LevelType type, int level) {
+        this.type = type;
+        this.level = level;
+    }
+    
+    public Level(LevelType type, int level, @Nullable String variation) {
         this.type = type;
         this.level = level;
         this.variation = variation;
@@ -57,7 +63,7 @@ public class Level extends GeneralLevel {
 
     @Override
     public String getFileName() {
-        return String.format("%s%s%s", getType(), getLevel() > 0 ? getLevel() : "", getVariation());
+        return String.format("%s%s", getType(), this.toString());
     }
 
     @Override
@@ -72,5 +78,10 @@ public class Level extends GeneralLevel {
             }
         }
         return kwdFile;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s%s", getLevel() > 0 ? getLevel() : "", getVariation());
     }
 }

--- a/src/toniarts/openkeeper/game/data/Settings.java
+++ b/src/toniarts/openkeeper/game/data/Settings.java
@@ -202,7 +202,7 @@ public class Settings {
 
         @Override
         public Object getDefaultValue() {
-            return defValue;
+            return defValue.getClass().isEnum() ? defValue.toString() : defValue;
         }
 
         public Integer getSpecialKey() {
@@ -433,8 +433,10 @@ public class Settings {
         switch (level.getType()) {
             case Level:
                 setSetting(Setting.LEVEL_STATUS.toString() + level, status);
+                break;
             case MPD:
                 setSetting(Setting.MPD_LEVEL_STATUS.toString() + level, status);
+                break;
         }
     }
 

--- a/src/toniarts/openkeeper/game/state/MainMenuScreenController.java
+++ b/src/toniarts/openkeeper/game/state/MainMenuScreenController.java
@@ -585,14 +585,9 @@ public class MainMenuScreenController implements IMainMenuScreenController {
      * Generates the movie list
      */
     private void generateMovieList() {
-        // TODO: We should only do that if the progress has changed and at the start of the game
-        Element movies = screen.findElementById("movieList");
+        Element movies = nifty.getScreen("movies").findElementById("movieList");
         if (movies == null) {
             return;
-        }
-
-        for (Element oldElement : movies.getChildren()) {
-            oldElement.markForRemoval();
         }
 
         int index = 0;
@@ -607,11 +602,34 @@ public class MainMenuScreenController implements IMainMenuScreenController {
                 action = "goToScreen(cutsceneLocked)";
             }
 
-            ControlBuilder control = new ControlBuilder("movie" + index++, "movieButton");
-            control.parameter("image", "Textures/Mov_Shots/M-" + image + "-0.png");
-            control.parameter("click", action);
-            control.parameter("moviename", cutscene.moviename);
-            control.build(nifty, screen, movies);
+            final String imagePath = "Textures/Mov_Shots/M-" + image + "-0.png";
+
+            if (movies.getChildrenCount() < CUTSCENES.size()) {
+                // initialise movie list
+                ControlBuilder control = new ControlBuilder("movie" + index, "movieButton");
+                control.parameter("image", imagePath);
+                control.parameter("click", action);
+                control.parameter("moviename", cutscene.moviename);
+                control.build(nifty, screen, movies);
+            } else {
+                // modify movie list if changed
+                Element element = movies.getChildren().get(index);
+                final String oldImagePath = element.getElementType().getAttributes().get("image");
+                
+                // has the control changed?
+                if (oldImagePath == null || !oldImagePath.contains(image)) {
+                    // insert before the old element
+                    ControlBuilder control = new ControlBuilder("movie" + index, "movieButton");
+                    control.parameter("image", imagePath);
+                    control.parameter("click", action);
+                    control.parameter("moviename", cutscene.moviename);
+                    control.build(nifty, screen, movies, element);
+                    
+                    // remove the old element
+                    element.markForRemoval();
+                }
+            }
+            index++;
         }
     }
 

--- a/src/toniarts/openkeeper/game/state/MainMenuScreenController.java
+++ b/src/toniarts/openkeeper/game/state/MainMenuScreenController.java
@@ -54,7 +54,9 @@ import toniarts.openkeeper.game.data.CustomMPDLevel;
 import toniarts.openkeeper.game.data.GameResult;
 import toniarts.openkeeper.game.data.HiScores;
 import toniarts.openkeeper.game.data.Level;
+import toniarts.openkeeper.game.data.Level.LevelType;
 import toniarts.openkeeper.game.data.Settings;
+import toniarts.openkeeper.game.data.Settings.LevelStatus;
 import toniarts.openkeeper.game.network.chat.ChatClientService;
 import toniarts.openkeeper.game.network.chat.ChatSessionListener;
 import toniarts.openkeeper.game.state.lobby.ClientInfo;
@@ -147,7 +149,7 @@ public class MainMenuScreenController implements IMainMenuScreenController {
 
     @Override
     public void selectMPDLevel(String number) {
-        state.selectedLevel = new Level(Level.LevelType.MPD, Integer.parseInt(number), null);
+        state.selectedLevel = new Level(Level.LevelType.MPD, Integer.parseInt(number));
         goToScreen("briefing");
     }
 
@@ -1004,12 +1006,46 @@ public class MainMenuScreenController implements IMainMenuScreenController {
         }
 
         /**
-         * TODO get real viewable Stub for checking if a cutscene is unlocked
+         * Check if a cutscene is unlocked
          *
-         * @return
+         * @return true if movie is viewable by the user
          */
         public boolean isViewable() {
-            return true;
+            boolean status = false;
+            if (this.click.startsWith("CutSceneLevel")) {
+                final int number = Integer.parseInt(this.image) + 1;
+
+                Level levela = null;
+                Level levelb = null;
+
+                switch (number) {
+                    case 11:
+                        levela = new Level(LevelType.Level, number, "a");
+                        levelb = new Level(LevelType.Level, number, "b");
+                        Level levelc = new Level(LevelType.Level, number, "c");
+                        status = isLevelCompleted(levela) || isLevelCompleted(levelb) || isLevelCompleted(levelc);
+                        break;
+                    case 6:
+                    case 15:
+                        levela = new Level(LevelType.Level, number, "a");
+                        levelb = new Level(LevelType.Level, number, "b");
+                        status = isLevelCompleted(levela) || isLevelCompleted(levelb);
+                        break;
+                    default:
+                        status = isLevelCompleted(new Level(LevelType.Level, number));
+                }
+            } else if (this.image.equals("Outro")) {
+                status = isLevelCompleted(new Level(LevelType.Level, 20));
+            } else if (this.image.equals("Intro")) {
+                // Intro is always visible
+                status = true;
+            }
+
+            return status;
+        }
+        
+        private boolean isLevelCompleted(Level level) {
+            return Settings.getInstance().getLevelStatus(level).equals(LevelStatus.COMPLETED);
         }
     }
 


### PR DESCRIPTION
This implements the missing check for the movie list. Movies can now be unlocked via winning a campaign level or by adding `LEVEL_STATUS7(string)=COMPLETED` in the user properties (only if you are a cheater 😉)