### PR TITLE
Nio stuff

### DIFF
--- a/src/toniarts/openkeeper/Main.java
+++ b/src/toniarts/openkeeper/Main.java
@@ -45,6 +45,8 @@ import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.AbstractMap;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -219,8 +221,16 @@ public class Main extends SimpleApplication {
     private static void initSettings(Main app) {
 
         // Create some folders
-        new File(USER_HOME_FOLDER).mkdirs();
-        new File(SCREENSHOTS_FOLDER).mkdirs();
+        try {
+            Files.createDirectories(Paths.get(USER_HOME_FOLDER));
+        } catch (IOException ex) {
+            LOGGER.log(Level.SEVERE, "Failed to create folder " + USER_HOME_FOLDER + "!", ex);
+        }
+        try {
+            Files.createDirectories(Paths.get(SCREENSHOTS_FOLDER));
+        } catch (IOException ex) {
+            LOGGER.log(Level.SEVERE, "Failed to create folder " + SCREENSHOTS_FOLDER + "!", ex);
+        }
 
         // Init the user settings (which in JME are app settings)
         app.settings = Settings.getInstance().getAppSettings();

--- a/src/toniarts/openkeeper/Main.java
+++ b/src/toniarts/openkeeper/Main.java
@@ -382,8 +382,8 @@ public class Main extends SimpleApplication {
 
                     // Load the XMLs, since we also validate them, Nifty will read them twice
                     List<Map.Entry<String, byte[]>> guiXMLs = new ArrayList<>(2);
-                    guiXMLs.add(new AbstractMap.SimpleImmutableEntry<>("Interface/MainMenu.xml", PathUtils.getBytesFromInputStream(Main.this.getClass().getResourceAsStream("/Interface/MainMenu.xml"))));
-                    guiXMLs.add(new AbstractMap.SimpleImmutableEntry<>("Interface/GameHUD.xml", PathUtils.getBytesFromInputStream(Main.this.getClass().getResourceAsStream("/Interface/GameHUD.xml"))));
+                    guiXMLs.add(new AbstractMap.SimpleImmutableEntry<>("Interface/MainMenu.xml", Files.readAllBytes(Paths.get(Main.this.getClass().getResource("/Interface/MainMenu.xml").toURI()))));
+                    guiXMLs.add(new AbstractMap.SimpleImmutableEntry<>("Interface/GameHUD.xml", Files.readAllBytes(Paths.get(Main.this.getClass().getResource("/Interface/GameHUD.xml").toURI()))));
 
                     // Validate the XML, great for debuging purposes
                     for (Map.Entry<String, byte[]> xml : guiXMLs) {

--- a/src/toniarts/openkeeper/Main.java
+++ b/src/toniarts/openkeeper/Main.java
@@ -46,6 +46,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.AbstractMap;
 import java.util.ArrayDeque;
@@ -565,9 +566,9 @@ public class Main extends SimpleApplication {
      * @return the resource bundle
      */
     public static ResourceBundle getResourceBundle(String baseName) {
-        File file = new File(AssetsConverter.getAssetsFolder());
+        Path file = Paths.get(AssetsConverter.getAssetsFolder());
         try {
-            URL[] urls = {file.toURI().toURL()};
+            URL[] urls = {file.toUri().toURL()};
             ClassLoader loader = new URLClassLoader(urls);
             return ResourceBundle.getBundle(baseName, Locale.getDefault(), loader, new UTF8Control());
         } catch (Exception e) {

--- a/src/toniarts/openkeeper/audio/plugins/converter/MpegToWav.java
+++ b/src/toniarts/openkeeper/audio/plugins/converter/MpegToWav.java
@@ -100,7 +100,7 @@ public class MpegToWav {
                 System.out.printf("Could not open output file %s!\n%s\n", args[1], e);
             }
         } catch (Exception e) {
-            System.out.printf("Could not open input file %s!\n", args[0]);
+            System.out.printf("Could not open input file %s!\n", args[0], e);
         }
     }
 }

--- a/src/toniarts/openkeeper/audio/plugins/converter/MpegToWav.java
+++ b/src/toniarts/openkeeper/audio/plugins/converter/MpegToWav.java
@@ -16,10 +16,13 @@
  */
 package toniarts.openkeeper.audio.plugins.converter;
 
-import java.io.FileInputStream;
+import java.io.BufferedInputStream;
+import java.io.InputStream;
 import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import toniarts.openkeeper.audio.plugins.decoder.AudioInformation;
 import toniarts.openkeeper.audio.plugins.decoder.Decoder;
 import toniarts.openkeeper.audio.plugins.decoder.MediaInformation;
@@ -54,11 +57,12 @@ public class MpegToWav {
             return;
         }
 
-        try (FileInputStream fin = new FileInputStream(args[0])) {
+        try (InputStream in = Files.newInputStream(Paths.get(args[0]));
+                BufferedInputStream bin = new BufferedInputStream(in)) {
 
             MpxReader reader = new MpxReader();
-            MediaInformation info = reader.readInformation(fin, true);
-            Decoder decoder = reader.getDecoder(fin, true);
+            MediaInformation info = reader.readInformation(bin, true);
+            Decoder decoder = reader.getDecoder(bin, true);
 
             try (RandomAccessFile fout = new RandomAccessFile(args[1], "rw")) {
                 System.out.printf("Decoding %s into %s ...\n", args[0], args[1]);

--- a/src/toniarts/openkeeper/game/MapSelector.java
+++ b/src/toniarts/openkeeper/game/MapSelector.java
@@ -50,7 +50,7 @@ public class MapSelector {
     public MapSelector() {
 
         // Get the maps
-        try (DirectoryStream<Path> stream = Files.newDirectoryStream(Paths.get(Main.getDkIIFolder() + PathUtils.DKII_MAPS_FOLDER), PathUtils.getFilterForFilesEndingWith(".kwd"))) {
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(Paths.get(Main.getDkIIFolder(), PathUtils.DKII_MAPS_FOLDER), PathUtils.getFilterForFilesEndingWith(".kwd"))) {
             for (Path file : stream) {
 
                 // Read the map

--- a/src/toniarts/openkeeper/game/MapSelector.java
+++ b/src/toniarts/openkeeper/game/MapSelector.java
@@ -50,12 +50,11 @@ public class MapSelector {
     public MapSelector() {
 
         // Get the maps
-        DirectoryStream.Filter<Path> filter = (Path entry) -> entry.getFileName().toString().toLowerCase().endsWith(".kwd") && !Files.isDirectory(entry);
-        try (DirectoryStream<Path> stream = Files.newDirectoryStream(Paths.get(Main.getDkIIFolder() + PathUtils.DKII_MAPS_FOLDER), filter)) {
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(Paths.get(Main.getDkIIFolder() + PathUtils.DKII_MAPS_FOLDER), PathUtils.getFilterForFilesEndingWith(".kwd"))) {
             for (Path file : stream) {
 
                 // Read the map
-                KwdFile kwd = new KwdFile(Main.getDkIIFolder(), file.toFile(), false);
+                KwdFile kwd = new KwdFile(Main.getDkIIFolder(), file, false);
                 GameMapContainer gameMapContainer = new GameMapContainer(kwd, kwd.getGameLevel().getName());
                 if (kwd.getGameLevel().getLvlFlags().contains(GameLevel.LevFlag.IS_SKIRMISH_LEVEL)) {
                     skirmishMaps.add(gameMapContainer);

--- a/src/toniarts/openkeeper/game/controller/GameController.java
+++ b/src/toniarts/openkeeper/game/controller/GameController.java
@@ -19,8 +19,8 @@ package toniarts.openkeeper.game.controller;
 import com.badlogic.gdx.ai.GdxAI;
 import com.jme3.util.SafeArrayList;
 import com.simsilica.es.EntityData;
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -200,7 +200,7 @@ public class GameController implements IGameLogicUpdatable, AutoCloseable, IGame
             if (level != null) {
 
                 kwdFile = new KwdFile(Main.getDkIIFolder(),
-                        new File(ConversionUtils.getRealFileName(Main.getDkIIFolder(), PathUtils.DKII_MAPS_FOLDER + level + ".kwd")));
+                        Paths.get(ConversionUtils.getRealFileName(Main.getDkIIFolder(), PathUtils.DKII_MAPS_FOLDER + level + ".kwd")));
 
             } else {
                 kwdFile.load();

--- a/src/toniarts/openkeeper/game/data/Level.java
+++ b/src/toniarts/openkeeper/game/data/Level.java
@@ -16,8 +16,8 @@
  */
 package toniarts.openkeeper.game.data;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import toniarts.openkeeper.Main;
@@ -42,7 +42,7 @@ public class Level extends GeneralLevel {
         this.type = type;
         this.level = level;
     }
-    
+
     public Level(LevelType type, int level, @Nullable String variation) {
         this.type = type;
         this.level = level;
@@ -72,7 +72,7 @@ public class Level extends GeneralLevel {
             try {
                 // Load the actual level info
                 kwdFile = new KwdFile(Main.getDkIIFolder(),
-                        new File(ConversionUtils.getRealFileName(Main.getDkIIFolder(), PathUtils.DKII_MAPS_FOLDER + getFileName() + ".kwd")), false);
+                        Paths.get(ConversionUtils.getRealFileName(Main.getDkIIFolder() + PathUtils.DKII_MAPS_FOLDER, getFileName() + ".kwd")), false);
             } catch (IOException ex) {
                 logger.log(java.util.logging.Level.SEVERE, "Failed to load the level file!", ex);
             }

--- a/src/toniarts/openkeeper/game/data/Settings.java
+++ b/src/toniarts/openkeeper/game/data/Settings.java
@@ -18,13 +18,16 @@ package toniarts.openkeeper.game.data;
 
 import com.jme3.input.KeyInput;
 import com.jme3.system.AppSettings;
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -266,10 +269,11 @@ public class Settings {
         if (!this.settings.containsKey("Width") || !this.settings.containsKey("Height")) {
             this.settings.setResolution(800, 600); // Default resolution
         }
-        File settingsFile = new File(USER_SETTINGS_FILE);
-        if (settingsFile.exists()) {
-            try (InputStream is = new FileInputStream(settingsFile)) {
-                this.settings.load(is);
+        Path settingsFile = Paths.get(USER_SETTINGS_FILE);
+        if (Files.exists(settingsFile)) {
+            try (InputStream in = Files.newInputStream(settingsFile);
+                    BufferedInputStream bin = new BufferedInputStream(in)) {
+                settings.load(bin);
             } catch (IOException ex) {
                 LOGGER.log(java.util.logging.Level.WARNING, "Settings file failed to load from " + settingsFile + "!", ex);
             }
@@ -300,8 +304,8 @@ public class Settings {
     }
 
     /**
-     * @see com.​jme3.​system.AppSettings.LWJGL_OPENGL* constants
-     * @return list of avaliable renderers
+     * @see com.jme3.system.AppSettings LWJGL_OPENGL constants
+     * @return list of available renderers
      */
     public static List<String> getRenderers() {
         List<String> renderers = new ArrayList<>();
@@ -325,8 +329,11 @@ public class Settings {
      * @throws java.io.IOException may fail to save
      */
     public void save() throws IOException {
-        try (OutputStream os = new FileOutputStream(new File(USER_SETTINGS_FILE))) {
-            settings.save(os);
+        try (OutputStream out = Files.newOutputStream(Paths.get(USER_SETTINGS_FILE));
+                BufferedOutputStream bout = new BufferedOutputStream(out)) {
+            settings.save(bout);
+        } catch (IOException ex) {
+            LOGGER.log(java.util.logging.Level.WARNING, "Settings file failed to save!", ex);
         }
     }
 

--- a/src/toniarts/openkeeper/game/data/Settings.java
+++ b/src/toniarts/openkeeper/game/data/Settings.java
@@ -20,7 +20,6 @@ import com.jme3.input.KeyInput;
 import com.jme3.system.AppSettings;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -249,8 +248,8 @@ public class Settings {
     private final static Settings INSTANCE;
     private final AppSettings settings;
     private final static int MAX_FPS = 200;
-    private final static String USER_HOME_FOLDER = System.getProperty("user.home").concat(File.separator).concat(".").concat(Main.TITLE).concat(File.separator);
-    private final static String USER_SETTINGS_FILE = USER_HOME_FOLDER.concat("openkeeper.properties");
+    private final static Path USER_HOME_FOLDER = Paths.get(System.getProperty("user.home"), ".".concat(Main.TITLE));
+    private final static Path USER_SETTINGS_FILE = USER_HOME_FOLDER.resolve("openkeeper.properties");
     public final static List<String> OPENGL = Settings.getRenderers();
     public final static List<Integer> SAMPLES = new ArrayList<>(Arrays.asList(new Integer[]{0, 2, 4, 6, 8, 16}));
     public final static List<Integer> ANISOTROPHIES = new ArrayList<>(Arrays.asList(new Integer[]{0, 2, 4, 8, 16}));
@@ -269,13 +268,12 @@ public class Settings {
         if (!this.settings.containsKey("Width") || !this.settings.containsKey("Height")) {
             this.settings.setResolution(800, 600); // Default resolution
         }
-        Path settingsFile = Paths.get(USER_SETTINGS_FILE);
-        if (Files.exists(settingsFile)) {
-            try (InputStream in = Files.newInputStream(settingsFile);
+        if (Files.exists(USER_SETTINGS_FILE)) {
+            try (InputStream in = Files.newInputStream(USER_SETTINGS_FILE);
                     BufferedInputStream bin = new BufferedInputStream(in)) {
                 settings.load(bin);
             } catch (IOException ex) {
-                LOGGER.log(java.util.logging.Level.WARNING, "Settings file failed to load from " + settingsFile + "!", ex);
+                LOGGER.log(java.util.logging.Level.WARNING, "Settings file failed to load from " + USER_SETTINGS_FILE + "!", ex);
             }
         }
         this.settings.setFrameRate(Math.max(MAX_FPS, settings.getFrequency()));
@@ -329,7 +327,7 @@ public class Settings {
      * @throws java.io.IOException may fail to save
      */
     public void save() throws IOException {
-        try (OutputStream out = Files.newOutputStream(Paths.get(USER_SETTINGS_FILE));
+        try (OutputStream out = Files.newOutputStream(USER_SETTINGS_FILE);
                 BufferedOutputStream bout = new BufferedOutputStream(out)) {
             settings.save(bout);
         } catch (IOException ex) {

--- a/src/toniarts/openkeeper/game/sound/SoundCategory.java
+++ b/src/toniarts/openkeeper/game/sound/SoundCategory.java
@@ -18,6 +18,9 @@ package toniarts.openkeeper.game.sound;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
@@ -28,8 +31,8 @@ import toniarts.openkeeper.tools.convert.ConversionUtils;
 import toniarts.openkeeper.tools.convert.sound.BankMapFile;
 import toniarts.openkeeper.tools.convert.sound.SdtFile;
 import toniarts.openkeeper.tools.convert.sound.sfx.SfxGroupEntry;
-import toniarts.openkeeper.tools.convert.sound.sfx.SfxMapFileEntry;
 import toniarts.openkeeper.tools.convert.sound.sfx.SfxMapFile;
+import toniarts.openkeeper.tools.convert.sound.sfx.SfxMapFileEntry;
 import toniarts.openkeeper.utils.PathUtils;
 
 /**
@@ -88,24 +91,27 @@ public class SoundCategory {
 
     @Nullable
     public SfxMapFile getSfxMapFile() {
-        File f = new File(PathUtils.getDKIIFolder() + folder
-                + name.toLowerCase() + "SFX.map");
-        if (f.exists()) {
+        try {
+            Path f = Paths.get(ConversionUtils.getRealFileName(PathUtils.getDKIIFolder(), folder + name.toLowerCase() + "SFX.map"));
+
             return new SfxMapFile(f);
+        } catch (IOException ex) {
+            LOGGER.log(Level.SEVERE, ex, () -> {
+                return String.format("Sfx file of category {0} does not exist", name);
+            });
         }
 
-        LOGGER.log(Level.SEVERE, "Sfx file of category {0} not exits", name);
         return null;
     }
 
     public BankMapFile getBankMapFile() {
-        File f = new File(PathUtils.getDKIIFolder() + folder
-                + name.toLowerCase() + "BANK.map");
-        if (f.exists()) {
-            return new BankMapFile(f);
-        }
+        try {
+            Path f = Paths.get(ConversionUtils.getRealFileName(PathUtils.getDKIIFolder(), folder + name.toLowerCase() + "BANK.map"));
 
-        throw new RuntimeException("Bank file of category " + name + " not exits");
+            return new BankMapFile(f);
+        } catch (IOException ex) {
+            throw new RuntimeException("Bank file of category " + name + " does not exist", ex);
+        }
     }
 
     /**
@@ -119,9 +125,9 @@ public class SoundCategory {
         // FIXME I don`t know what better HD or HW, but quantity HW less than HD, but size HW more than HD
         for (String part : new String[]{"HD.sdt", "HW.sdt"}) {
             try {
-                File f = new File(ConversionUtils.getRealFileName(PathUtils.getDKIIFolder(),
+                Path f = Paths.get(ConversionUtils.getRealFileName(PathUtils.getDKIIFolder(),
                         PathUtils.DKII_SFX_FOLDER + archiveFilename + part));
-                if (f.exists()) {
+                if (Files.exists(f)) {
                     return new SdtFile(f);
                 }
             } catch (IOException ex) {

--- a/src/toniarts/openkeeper/game/sound/SoundGroup.java
+++ b/src/toniarts/openkeeper/game/sound/SoundGroup.java
@@ -17,6 +17,7 @@
 package toniarts.openkeeper.game.sound;
 
 import java.io.File;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
@@ -78,8 +79,8 @@ public class SoundGroup {
                     throw new RuntimeException("Sdt file " + archiveFilename + " does not exist");
                 }
 
-                String relative = new File(PathUtils.getDKIIFolder()
-                        + PathUtils.DKII_SFX_FOLDER).toPath().relativize(sdt.getFile()).toString();
+                String relative = Paths.get(PathUtils.getDKIIFolder(), PathUtils.DKII_SFX_FOLDER)
+                        .relativize(sdt.getFile()).toString();
 
                 try {
                     String soundFilename = relative.substring(0, relative.length() - 4) + File.separator

--- a/src/toniarts/openkeeper/game/sound/SoundGroup.java
+++ b/src/toniarts/openkeeper/game/sound/SoundGroup.java
@@ -79,7 +79,7 @@ public class SoundGroup {
                 }
 
                 String relative = new File(PathUtils.getDKIIFolder()
-                        + PathUtils.DKII_SFX_FOLDER).toPath().relativize(sdt.getFile().toPath()).toString();
+                        + PathUtils.DKII_SFX_FOLDER).toPath().relativize(sdt.getFile()).toString();
 
                 try {
                     String soundFilename = relative.substring(0, relative.length() - 4) + File.separator
@@ -88,7 +88,9 @@ public class SoundGroup {
                     SoundFile sf = new SoundFile(this, soundId, soundFilename);
                     files.add(sf);
                 } catch (Exception ex) {
-                    LOGGER.log(Level.SEVERE, ex.getMessage() + " in file " + sdt.getFile().getName() + " with id " + soundId, ex);
+                    LOGGER.log(Level.SEVERE, ex, () -> {
+                        return "Error in file " + sdt.getFile().toString() + " with id " + soundId;
+                    });
                 }
             }
         }

--- a/src/toniarts/openkeeper/game/state/GameState.java
+++ b/src/toniarts/openkeeper/game/state/GameState.java
@@ -19,8 +19,8 @@ package toniarts.openkeeper.game.state;
 import com.badlogic.gdx.ai.GdxAI;
 import com.jme3.app.Application;
 import com.jme3.app.state.AppStateManager;
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -160,7 +160,7 @@ public class GameState extends AbstractPauseAwareState implements IGameLogicUpda
                     // Load the level data
                     if (level != null) {
                         kwdFile = new KwdFile(Main.getDkIIFolder(),
-                                new File(ConversionUtils.getRealFileName(Main.getDkIIFolder(), PathUtils.DKII_MAPS_FOLDER + level + ".kwd")));
+                                Paths.get(ConversionUtils.getRealFileName(Main.getDkIIFolder() + PathUtils.DKII_MAPS_FOLDER, level + ".kwd")));
                     } else {
                         kwdFile.load();
                     }

--- a/src/toniarts/openkeeper/game/state/MainMenuState.java
+++ b/src/toniarts/openkeeper/game/state/MainMenuState.java
@@ -32,6 +32,7 @@ import java.awt.DisplayMode;
 import java.awt.GraphicsDevice;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
@@ -103,8 +104,9 @@ public class MainMenuState extends AbstractAppState {
      * (has its own loading screen here)
      * @param assetManager asset manager for loading the screen
      * @param app the main application
+     * @throws java.io.IOException may fail to load the main menu map scene
      */
-    public MainMenuState(final boolean enabled, final AssetManager assetManager, final Main app) {
+    public MainMenuState(final boolean enabled, final AssetManager assetManager, final Main app) throws IOException {
         listener = new MainMenuInteraction(this);
         super.setEnabled(enabled);
 
@@ -122,11 +124,10 @@ public class MainMenuState extends AbstractAppState {
      * @param loadingScreen optional loading screen
      * @param assetManager asset manager
      */
-    private void loadMenuScene(final SingleBarLoadingState loadingScreen, final AssetManager assetManager, final Main app) {
+    private void loadMenuScene(final SingleBarLoadingState loadingScreen, final AssetManager assetManager, final Main app) throws IOException {
 
         // Load the 3D Front end
-        kwdFile = new KwdFile(Main.getDkIIFolder(), new File(Main.getDkIIFolder()
-                + PathUtils.DKII_MAPS_FOLDER + "FrontEnd3DLevel.kwd"));
+        kwdFile = new KwdFile(Main.getDkIIFolder(), Paths.get(ConversionUtils.getRealFileName(Main.getDkIIFolder() + PathUtils.DKII_MAPS_FOLDER, "FrontEnd3DLevel.kwd")));
         if (loadingScreen != null) {
             loadingScreen.setProgress(0.25f);
         }
@@ -253,7 +254,11 @@ public class MainMenuState extends AbstractAppState {
 
                     @Override
                     public void onLoad() {
-                        loadMenuScene(this, MainMenuState.this.assetManager, MainMenuState.this.app);
+                        try {
+                            loadMenuScene(this, MainMenuState.this.assetManager, MainMenuState.this.app);
+                        } catch (IOException ex) {
+                            LOGGER.log(Level.SEVERE, "Failed to load the main menu scene!", ex);
+                        }
                     }
 
                     @Override

--- a/src/toniarts/openkeeper/game/state/session/LocalGameSession.java
+++ b/src/toniarts/openkeeper/game/state/session/LocalGameSession.java
@@ -16,9 +16,11 @@ import com.simsilica.es.EntityId;
 import com.simsilica.es.base.DefaultEntityData;
 import java.awt.Point;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -77,17 +79,17 @@ public class LocalGameSession implements GameSessionServerService, GameSessionCl
      * @param level the level to load
      * @param campaign whether to start this level as a campaign level
      * @param stateManager state manager instance for setting up the game
+     * @param app the main app
      * @throws java.io.IOException Problem with the map file
      */
     public static void createLocalGame(String level, boolean campaign, AppStateManager stateManager, Main app) throws IOException {
 
         // Try to load the file
-        String mapFile = ConversionUtils.getRealFileName(Main.getDkIIFolder(), PathUtils.DKII_MAPS_FOLDER + level + ".kwd");
-        File file = new File(mapFile);
-        if (!file.exists()) {
-            throw new FileNotFoundException(mapFile);
+        Path mapFile = Paths.get(ConversionUtils.getRealFileName(Main.getDkIIFolder() + PathUtils.DKII_MAPS_FOLDER, level + ".kwd"));
+        if (!Files.exists(mapFile)) {
+            throw new FileNotFoundException(mapFile.toString());
         }
-        KwdFile kwdFile = new KwdFile(Main.getDkIIFolder(), file);
+        KwdFile kwdFile = new KwdFile(Main.getDkIIFolder(), mapFile);
 
         createLocalGame(kwdFile, stateManager, campaign, app);
     }

--- a/src/toniarts/openkeeper/tools/convert/BankMapLoader.java
+++ b/src/toniarts/openkeeper/tools/convert/BankMapLoader.java
@@ -16,7 +16,6 @@
  */
 package toniarts.openkeeper.tools.convert;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
@@ -41,7 +40,7 @@ public class BankMapLoader {
     public static void main(String[] args) throws IOException {
 
         // Take Dungeon Keeper 2 root folder as parameter
-        if (args.length != 1 || !new File(args[0]).exists()) {
+        if (args.length != 1 || !Files.exists(Paths.get(args[0]))) {
             dkIIFolder = PathUtils.getDKIIFolder();
             if (dkIIFolder == null)
             {

--- a/src/toniarts/openkeeper/tools/convert/BankMapLoader.java
+++ b/src/toniarts/openkeeper/tools/convert/BankMapLoader.java
@@ -21,11 +21,11 @@ import java.io.IOException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.List;
-
 import toniarts.openkeeper.tools.convert.sound.BankMapFile;
 import toniarts.openkeeper.utils.PathUtils;
 
@@ -40,7 +40,7 @@ public class BankMapLoader {
 
     public static void main(String[] args) throws IOException {
 
-        //Take Dungeon Keeper 2 root folder as parameter
+        // Take Dungeon Keeper 2 root folder as parameter
         if (args.length != 1 || !new File(args[0]).exists()) {
             dkIIFolder = PathUtils.getDKIIFolder();
             if (dkIIFolder == null)
@@ -51,27 +51,26 @@ public class BankMapLoader {
             dkIIFolder = PathUtils.fixFilePath(args[0]);
         }
 
-        final String soundFolder = dkIIFolder + PathUtils.DKII_SFX_FOLDER;
+        final Path soundFolder = Paths.get(dkIIFolder, PathUtils.DKII_SFX_FOLDER);
 
-        //Find all the bank.map files
-        final List<File> bankMapFiles = new ArrayList<>();
-        File dataDir = new File(soundFolder);
-        Files.walkFileTree(dataDir.toPath(), new SimpleFileVisitor<Path>() {
+        // Find all the bank.map files
+        final List<Path> bankMapFiles = new ArrayList<>();
+        Files.walkFileTree(soundFolder, new SimpleFileVisitor<Path>() {
             @Override
             public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
 
-                //Get all the SDT files
-                if (attrs.isRegularFile() && file.getFileName().toString().toLowerCase().endsWith("bank.map")) {
-                    bankMapFiles.add(file.toFile());
+                // Get all the SDT files
+                if (file.getFileName().toString().toLowerCase().endsWith("bank.map") && attrs.isRegularFile()) {
+                    bankMapFiles.add(file);
                 }
 
-                //Always continue
+                // Always continue
                 return FileVisitResult.CONTINUE;
             }
         });
 
-        //Just open up the bank map files for fun
-        for (File file : bankMapFiles) {
+        // Just open up the bank map files for fun
+        for (Path file : bankMapFiles) {
             BankMapFile bankMap = new BankMapFile(file);
             if (bankMap != null) {
                 continue; // For debugging

--- a/src/toniarts/openkeeper/tools/convert/Bf4Extractor.java
+++ b/src/toniarts/openkeeper/tools/convert/Bf4Extractor.java
@@ -21,12 +21,12 @@ import java.io.IOException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.List;
 import javax.imageio.ImageIO;
-
 import toniarts.openkeeper.tools.convert.bf4.Bf4Entry;
 import toniarts.openkeeper.tools.convert.bf4.Bf4File;
 import toniarts.openkeeper.utils.PathUtils;
@@ -42,7 +42,7 @@ public class Bf4Extractor {
 
     public static void main(String[] args) throws IOException {
 
-        //Take Dungeon Keeper 2 root folder as parameter
+        // Take Dungeon Keeper 2 root folder as parameter
         if (args.length != 2 || !new File(args[1]).exists()) {
             dkIIFolder = PathUtils.getDKIIFolder();
             if (dkIIFolder == null || args.length == 0)
@@ -53,35 +53,34 @@ public class Bf4Extractor {
             dkIIFolder = PathUtils.fixFilePath(args[1]);
         }
 
-        final String textFolder = dkIIFolder + PathUtils.DKII_TEXT_DEFAULT_FOLDER;
+        final Path textFolder = Paths.get(dkIIFolder, PathUtils.DKII_TEXT_DEFAULT_FOLDER);
 
-        //And the destination
+        // And the destination
         String destination = PathUtils.fixFilePath(args[0]);
 
-        //Find all the font files
-        final List<File> bf4Files = new ArrayList<>();
-        File dataDir = new File(textFolder);
-        Files.walkFileTree(dataDir.toPath(), new SimpleFileVisitor<Path>() {
+        // Find all the font files
+        final List<Path> bf4Files = new ArrayList<>();
+        Files.walkFileTree(textFolder, new SimpleFileVisitor<Path>() {
             @Override
             public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
 
-                //Get all the BF4 files
-                if (attrs.isRegularFile() && file.getFileName().toString().toLowerCase().endsWith(".bf4")) {
-                    bf4Files.add(file.toFile());
+                // Get all the BF4 files
+                if (file.getFileName().toString().toLowerCase().endsWith(".bf4") && attrs.isRegularFile()) {
+                    bf4Files.add(file);
                 }
 
-                //Always continue
+                // Always continue
                 return FileVisitResult.CONTINUE;
             }
         });
 
-        //Extract the fonts bitmaps
-        for (File file : bf4Files) {
+        // Extract the fonts bitmaps
+        for (Path file : bf4Files) {
             Bf4File bf4 = new Bf4File(file);
 
             for (Bf4Entry entry : bf4) {
                 if (entry.getImage() != null) {
-                    String baseDir = destination + ConversionUtils.stripFileName(file.getName()) + File.separator;
+                    String baseDir = destination + ConversionUtils.stripFileName(file.toString()) + File.separator;
                     new File(baseDir).mkdirs();
                     ImageIO.write(entry.getImage(), "png", new File(baseDir
                             + ConversionUtils.stripFileName(entry.toString()) + "_"

--- a/src/toniarts/openkeeper/tools/convert/Bf4Extractor.java
+++ b/src/toniarts/openkeeper/tools/convert/Bf4Extractor.java
@@ -43,7 +43,7 @@ public class Bf4Extractor {
     public static void main(String[] args) throws IOException {
 
         // Take Dungeon Keeper 2 root folder as parameter
-        if (args.length != 2 || !new File(args[1]).exists()) {
+        if (args.length != 2 || !Files.exists(Paths.get(args[1]))) {
             dkIIFolder = PathUtils.getDKIIFolder();
             if (dkIIFolder == null || args.length == 0)
             {

--- a/src/toniarts/openkeeper/tools/convert/Bf4Extractor.java
+++ b/src/toniarts/openkeeper/tools/convert/Bf4Extractor.java
@@ -81,7 +81,7 @@ public class Bf4Extractor {
             for (Bf4Entry entry : bf4) {
                 if (entry.getImage() != null) {
                     String baseDir = destination + ConversionUtils.stripFileName(file.toString()) + File.separator;
-                    new File(baseDir).mkdirs();
+                    Files.createDirectories(Paths.get(baseDir));
                     ImageIO.write(entry.getImage(), "png", new File(baseDir
                             + ConversionUtils.stripFileName(entry.toString()) + "_"
                             + Integer.toString(entry.getCharacter()) + ".png"));

--- a/src/toniarts/openkeeper/tools/convert/ByteArrayResourceReader.java
+++ b/src/toniarts/openkeeper/tools/convert/ByteArrayResourceReader.java
@@ -85,7 +85,14 @@ public class ByteArrayResourceReader implements IResourceReader {
 
     @Override
     public IResourceChunkReader readChunk(int size) throws IOException {
-        ByteBuffer buf = ByteBuffer.wrap(buffer.array(), buffer.position(), size);
+        if (buffer.remaining() < size) {
+            String message = "Error reading byte array. Expect %s bytes and %s given";
+            throw new IOException(String.format(message, size, buffer.remaining()));
+        }
+        byte[] bytes = new byte[size];
+        System.arraycopy(buffer.array(), buffer.position(), bytes, 0, size);
+
+        ByteBuffer buf = ByteBuffer.wrap(bytes);
         buf.order(ByteOrder.LITTLE_ENDIAN);
 
         // Advance marker

--- a/src/toniarts/openkeeper/tools/convert/ByteArrayResourceReader.java
+++ b/src/toniarts/openkeeper/tools/convert/ByteArrayResourceReader.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2014-2020 OpenKeeper
+ *
+ * OpenKeeper is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * OpenKeeper is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenKeeper.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package toniarts.openkeeper.tools.convert;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+/**
+ * A version of Dungeon Keeper 2 resource reader that reads data directly from
+ * given byte array. Convenient if we already read all the data and
+ * decompressed/decrypted it. No need to swing it through a temp file etc.
+ *
+ * @author Toni Helenius <helenius.toni@gmail.com>
+ */
+public class ByteArrayResourceReader implements IResourceReader {
+
+    private final ByteBuffer buffer;
+
+    public ByteArrayResourceReader(byte[] data) {
+        buffer = ByteBuffer.wrap(data);
+        buffer.order(ByteOrder.LITTLE_ENDIAN);
+    }
+
+    @Override
+    public long getFilePointer() throws IOException {
+        return buffer.position();
+    }
+
+    @Override
+    public boolean isEof() throws IOException {
+        return !buffer.hasRemaining();
+    }
+
+    @Override
+    public long length() throws IOException {
+        return buffer.capacity();
+    }
+
+    @Override
+    public int read(byte[] b) throws IOException {
+        int length = Math.min(b.length, buffer.remaining());
+        System.arraycopy(buffer.array(), buffer.position(), b, 0, length);
+
+        // Advance marker
+        skipBytes(length);
+
+        return length;
+    }
+
+    @Override
+    public byte[] read(int length) throws IOException {
+        if (buffer.remaining() < length) {
+            String message = "Error reading byte array. Expect %s bytes and %s given";
+            throw new IOException(String.format(message, length, buffer.remaining()));
+        }
+
+        byte[] bytes = new byte[length];
+        System.arraycopy(buffer.array(), buffer.position(), bytes, 0, length);
+
+        // Advance marker
+        skipBytes(length);
+
+        return bytes;
+    }
+
+    @Override
+    public void seek(long pos) throws IOException {
+        buffer.position((int) pos);
+    }
+
+    @Override
+    public IResourceChunkReader readChunk(int size) throws IOException {
+        ByteBuffer buf = ByteBuffer.wrap(buffer.array(), buffer.position(), size);
+        buf.order(ByteOrder.LITTLE_ENDIAN);
+
+        // Advance marker
+        skipBytes(size);
+
+        return new ResourceChunkReader(buf);
+    }
+
+    @Override
+    public IResourceChunkReader readAll() throws IOException {
+        return readChunk(buffer.remaining());
+    }
+
+    @Override
+    public void skipBytes(int size) throws IOException {
+        buffer.position(buffer.position() + size);
+    }
+
+    @Override
+    public void close() throws IOException {
+        // NOP
+    }
+
+}

--- a/src/toniarts/openkeeper/tools/convert/FileResourceReader.java
+++ b/src/toniarts/openkeeper/tools/convert/FileResourceReader.java
@@ -34,19 +34,19 @@ import java.util.logging.Logger;
  *
  * @author archdemon
  */
-public class ResourceReader implements IResourceReader {
+public class FileResourceReader implements IResourceReader {
 
     private final SeekableByteChannel file;
     private final ByteBuffer buf;
 
     private static final int DEFAULT_BUFFER_SIZE = 8192;
-    private static final Logger LOGGER = Logger.getLogger(ResourceReader.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(FileResourceReader.class.getName());
 
-    public ResourceReader(String filename) throws IOException {
+    public FileResourceReader(String filename) throws IOException {
         this(Paths.get(filename));
     }
 
-    public ResourceReader(Path path) throws IOException {
+    public FileResourceReader(Path path) throws IOException {
         file = Files.newByteChannel(path, StandardOpenOption.READ);
         buf = ByteBuffer.allocateDirect(DEFAULT_BUFFER_SIZE);
         buf.order(ByteOrder.LITTLE_ENDIAN);
@@ -131,7 +131,7 @@ public class ResourceReader implements IResourceReader {
     /**
      * End of file
      *
-     * @return true if filepointer >= length of file
+     * @return true if file pointer >= length of file
      * @throws IOException
      */
     @Override

--- a/src/toniarts/openkeeper/tools/convert/KmfModelLoader.java
+++ b/src/toniarts/openkeeper/tools/convert/KmfModelLoader.java
@@ -152,7 +152,7 @@ public class KmfModelLoader implements AssetLoader {
             kmfFile = ((KmfAssetInfo) assetInfo).getKmfFile();
             generateMaterialFile = ((KmfAssetInfo) assetInfo).isGenerateMaterialFile();
         } else {
-            kmfFile = new KmfFile(readAssetStream(assetInfo.openStream()));
+            kmfFile = new KmfFile(readAssetStream(assetInfo));
         }
 
         // Create a root
@@ -196,9 +196,12 @@ public class KmfModelLoader implements AssetLoader {
         }
     }
 
-    private byte[] readAssetStream(InputStream assetStream) throws IOException {
-        try (BufferedInputStream bis = new BufferedInputStream(assetStream);
+    private byte[] readAssetStream(AssetInfo assetInfo) throws IOException {
+        try (InputStream is = assetInfo.openStream();
+                BufferedInputStream bis = new BufferedInputStream(is);
                 ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+
+            // TODO: Java 9 has readAll, if it is buffered use it
             int read;
             final int bufLen = 8192;
             byte[] buf = new byte[bufLen];

--- a/src/toniarts/openkeeper/tools/convert/KmfModelLoader.java
+++ b/src/toniarts/openkeeper/tools/convert/KmfModelLoader.java
@@ -46,6 +46,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -108,7 +109,7 @@ public class KmfModelLoader implements AssetLoader {
     public static void main(final String[] args) throws IOException {
 
         //Take Dungeon Keeper 2 root folder as parameter
-        if (args.length != 2 || !new File(args[1]).exists()) {
+        if (args.length != 2 || !Files.exists(Paths.get(args[1]))) {
             dkIIFolder = PathUtils.getDKIIFolder();
             if (dkIIFolder == null) {
                 throw new RuntimeException("Please provide file path to the model as a first parameter! Second parameter is the Dungeon Keeper II main folder (optional)");
@@ -656,13 +657,14 @@ public class KmfModelLoader implements AssetLoader {
                     materialLocation = AssetsConverter.getAssetsFolder().concat(AssetsConverter.MATERIALS_FOLDER.concat(File.separator).concat(fileName).concat(".j3m"));
 
                     // See if it exists
-                    File file = new File(materialLocation).getCanonicalFile();
-                    if (file.exists()) {
-                        if (!file.getName().equals(fileName.concat(".j3m"))) {
+                    Path file = Paths.get(materialLocation);
+                    if (Files.exists(file)) {
+                        file = file.toRealPath();
+                        if (!file.getFileName().toString().equals(fileName.concat(".j3m"))) {
 
                             // Case sensitivity issue
-                            materialKey = AssetsConverter.MATERIALS_FOLDER.concat("/").concat(file.getName());
-                            materialLocation = AssetsConverter.getAssetsFolder().concat(AssetsConverter.MATERIALS_FOLDER.concat(File.separator).concat(file.getName()));
+                            materialKey = AssetsConverter.MATERIALS_FOLDER.concat("/").concat(file.getFileName().toString());
+                            materialLocation = AssetsConverter.getAssetsFolder().concat(AssetsConverter.MATERIALS_FOLDER.concat(File.separator).concat(file.getFileName().toString()));
                         }
                         material = assetInfo.getManager().loadMaterial(materialKey);
                     }

--- a/src/toniarts/openkeeper/tools/convert/KmfModelLoader.java
+++ b/src/toniarts/openkeeper/tools/convert/KmfModelLoader.java
@@ -46,6 +46,8 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -136,7 +138,7 @@ public class KmfModelLoader implements AssetLoader {
             }
         };
 
-        ModelViewer app = new ModelViewer(new File(args[0]), dkIIFolder);
+        ModelViewer app = new ModelViewer(Paths.get(args[0]), dkIIFolder);
         app.start();
     }
 
@@ -201,14 +203,14 @@ public class KmfModelLoader implements AssetLoader {
      * @return random access file
      * @throws IOException
      */
-    public static File inputStreamToFile(InputStream is, String prefix) throws IOException {
+    public static Path inputStreamToFile(InputStream is, String prefix) throws IOException {
         File tempFile = File.createTempFile(prefix, "kmf");
         tempFile.deleteOnExit();
 
-        //Write the file
+        // Write the file
         try (BufferedOutputStream output = new BufferedOutputStream(new FileOutputStream(tempFile))) {
 
-            //Write in blocks
+            // Write in blocks
             byte[] buffer = new byte[2048];
             int tmp;
 
@@ -217,7 +219,7 @@ public class KmfModelLoader implements AssetLoader {
             }
         }
 
-        return tempFile;
+        return tempFile.toPath();
     }
 
     /**

--- a/src/toniarts/openkeeper/tools/convert/KmfModelLoader.java
+++ b/src/toniarts/openkeeper/tools/convert/KmfModelLoader.java
@@ -46,6 +46,8 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -763,9 +765,11 @@ public class KmfModelLoader implements AssetLoader {
                     m.setKey(new MaterialKey(materialKey));
 
                     // Save
-                    File materialFile = new File(materialLocation);
                     J3MExporter exporter = new J3MExporter();
-                    exporter.save(m, materialFile);
+                    try (OutputStream out = Files.newOutputStream(Paths.get(materialLocation));
+                            BufferedOutputStream bout = new BufferedOutputStream(out)) {
+                        exporter.save(m, bout);
+                    }
 
                     // Put the first one to the cache
                     if (k == 0) {

--- a/src/toniarts/openkeeper/tools/convert/KmfModelLoader.java
+++ b/src/toniarts/openkeeper/tools/convert/KmfModelLoader.java
@@ -18,7 +18,6 @@ package toniarts.openkeeper.tools.convert;
 
 import com.jme3.animation.AnimControl;
 import com.jme3.asset.AssetInfo;
-import com.jme3.asset.AssetKey;
 import com.jme3.asset.AssetLoader;
 import com.jme3.asset.MaterialKey;
 import com.jme3.asset.ModelKey;
@@ -43,8 +42,6 @@ import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -119,25 +116,6 @@ public class KmfModelLoader implements AssetLoader {
         } else {
             dkIIFolder = PathUtils.fixFilePath(args[1]);
         }
-
-        AssetInfo ai = new AssetInfo(/*main.getAssetManager()*/null, null) {
-            @Override
-            public InputStream openStream() {
-                try {
-                    final File file = new File(dkIIFolder);
-                    key = new AssetKey() {
-                        @Override
-                        public String getName() {
-                            return file.toPath().getFileName().toString();
-                        }
-                    };
-                    return new FileInputStream(file);
-                } catch (FileNotFoundException ex) {
-                    logger.log(Level.SEVERE, null, ex);
-                }
-                return null;
-            }
-        };
 
         ModelViewer app = new ModelViewer(Paths.get(args[0]), dkIIFolder);
         app.start();

--- a/src/toniarts/openkeeper/tools/convert/MapLoader.java
+++ b/src/toniarts/openkeeper/tools/convert/MapLoader.java
@@ -17,6 +17,7 @@
 package toniarts.openkeeper.tools.convert;
 
 import java.io.File;
+import java.nio.file.Paths;
 import toniarts.openkeeper.tools.convert.map.KwdFile;
 import toniarts.openkeeper.utils.PathUtils;
 
@@ -43,6 +44,6 @@ public class MapLoader {
         }
 
         // Load the map
-        KwdFile kwd = new KwdFile(dkIIFolder, new File(args[0]));
+        KwdFile kwd = new KwdFile(dkIIFolder, Paths.get(args[0]));
     }
 }

--- a/src/toniarts/openkeeper/tools/convert/MapLoader.java
+++ b/src/toniarts/openkeeper/tools/convert/MapLoader.java
@@ -16,7 +16,7 @@
  */
 package toniarts.openkeeper.tools.convert;
 
-import java.io.File;
+import java.nio.file.Files;
 import java.nio.file.Paths;
 import toniarts.openkeeper.tools.convert.map.KwdFile;
 import toniarts.openkeeper.utils.PathUtils;
@@ -33,7 +33,7 @@ public class MapLoader {
     public static void main(String[] args) {
 
         // Take Dungeon Keeper 2 root folder as parameter
-        if (args.length != 2 || !new File(args[1]).exists()) {
+        if (args.length != 2 || !Files.exists(Paths.get(args[1]))) {
             dkIIFolder = PathUtils.getDKIIFolder();
             if (dkIIFolder == null || args.length == 0)
             {

--- a/src/toniarts/openkeeper/tools/convert/ResourceReader.java
+++ b/src/toniarts/openkeeper/tools/convert/ResourceReader.java
@@ -16,7 +16,6 @@
  */
 package toniarts.openkeeper.tools.convert;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -40,10 +39,6 @@ public class ResourceReader implements IResourceReader {
     private final SeekableByteChannel file;
 
     private static final Logger LOGGER = Logger.getLogger(ResourceReader.class.getName());
-
-    public ResourceReader(File file) throws IOException {
-        this(file.toPath());
-    }
 
     public ResourceReader(String filename) throws IOException {
         this(Paths.get(filename));

--- a/src/toniarts/openkeeper/tools/convert/SoundExtractor.java
+++ b/src/toniarts/openkeeper/tools/convert/SoundExtractor.java
@@ -16,7 +16,6 @@
  */
 package toniarts.openkeeper.tools.convert;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
@@ -44,7 +43,7 @@ public class SoundExtractor {
     public static void main(String[] args) throws IOException {
 
         // Take Dungeon Keeper 2 root folder as parameter
-        if (args.length != 2 || !new File(args[1]).exists()) {
+        if (args.length != 2 || !Files.exists(Paths.get(args[1]))) {
             dkIIFolder = PathUtils.getDKIIFolder();
             if (dkIIFolder == null || args.length == 0)
             {

--- a/src/toniarts/openkeeper/tools/convert/SoundExtractor.java
+++ b/src/toniarts/openkeeper/tools/convert/SoundExtractor.java
@@ -21,13 +21,13 @@ import java.io.IOException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.List;
 import toniarts.openkeeper.tools.convert.sound.BankMapFile;
 import toniarts.openkeeper.tools.convert.sound.SFFile;
-
 import toniarts.openkeeper.tools.convert.sound.SdtFile;
 import toniarts.openkeeper.tools.convert.sound.sfx.SfxMapFile;
 import toniarts.openkeeper.utils.PathUtils;
@@ -43,7 +43,7 @@ public class SoundExtractor {
 
     public static void main(String[] args) throws IOException {
 
-        //Take Dungeon Keeper 2 root folder as parameter
+        // Take Dungeon Keeper 2 root folder as parameter
         if (args.length != 2 || !new File(args[1]).exists()) {
             dkIIFolder = PathUtils.getDKIIFolder();
             if (dkIIFolder == null || args.length == 0)
@@ -54,21 +54,20 @@ public class SoundExtractor {
             dkIIFolder = PathUtils.fixFilePath(args[1]);
         }
 
-        final String soundFolder = dkIIFolder + PathUtils.DKII_SFX_FOLDER;
+        final Path soundFolder = Paths.get(dkIIFolder, PathUtils.DKII_SFX_FOLDER);
 
-        //And the destination
+        // And the destination
         String destination = PathUtils.fixFilePath(args[0]);
 
-        //Find all the sound files
-        final List<File> sdtFiles = new ArrayList<>();
-        File dataDir = new File(soundFolder);
-        //Find all the bank.map files
-        final List<File> bankMapFiles = new ArrayList<>();
-        //Find all the bank.map files
-        final List<File> sfxMapFiles = new ArrayList<>();
-        //Find all the bank.map files
-        final List<File> sf2Files = new ArrayList<>();
-        Files.walkFileTree(dataDir.toPath(), new SimpleFileVisitor<Path>() {
+        // Find all the sound files
+        final List<Path> sdtFiles = new ArrayList<>();
+        // Find all the bank.map files
+        final List<Path> bankMapFiles = new ArrayList<>();
+        // Find all the bank.map files
+        final List<Path> sfxMapFiles = new ArrayList<>();
+        // Find all the bank.map files
+        final List<Path> sf2Files = new ArrayList<>();
+        Files.walkFileTree(soundFolder, new SimpleFileVisitor<Path>() {
             @Override
             public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
 
@@ -76,13 +75,13 @@ public class SoundExtractor {
                 if (attrs.isRegularFile()) {
                     String filename = file.getFileName().toString().toLowerCase();
                     if (filename.endsWith(".sdt")){
-                        sdtFiles.add(file.toFile());
+                        sdtFiles.add(file);
                     } else if (filename.endsWith(".sf2")) {
-                        sf2Files.add(file.toFile());
+                        sf2Files.add(file);
                     } else if (filename.endsWith("bank.map")) {
-                        bankMapFiles.add(file.toFile());
+                        bankMapFiles.add(file);
                     } else if (filename.endsWith("sfx.map")) {
-                        sfxMapFiles.add(file.toFile());
+                        sfxMapFiles.add(file);
                     }
                 }
 
@@ -92,34 +91,34 @@ public class SoundExtractor {
         });
 
         // TODO unpack files
-        //Just open up the bank map files for fun
-        for (File file : bankMapFiles) {
+        // Just open up the bank map files for fun
+        for (Path file : bankMapFiles) {
             BankMapFile bankMap = new BankMapFile(file);
-            //System.out.println(bankMap);
+            // System.out.println(bankMap);
         }
-        //Just open up the sfx map files for fun
-        for (File file : sfxMapFiles) {
+        // Just open up the sfx map files for fun
+        for (Path file : sfxMapFiles) {
             SfxMapFile sfxMap = new SfxMapFile(file);
             //System.out.println(sfxMap);
         }
-        //Just open up the sf2 map files for fun
-        for (File file : sf2Files) {
+        // Just open up the sf2 map files for fun
+        for (Path file : sf2Files) {
             SFFile sf2File = new SFFile(file);
             //System.out.println(sf2File);
         }
-        //Extract the sounds
-        for (File file : sdtFiles) {
+        // Extract the sounds
+        for (Path file : sdtFiles) {
             SdtFile sdt = new SdtFile(file);
 
-            //Get a relative path
-            Path relative = dataDir.toPath().relativize(file.toPath());
+            // Get a relative path
+            Path relative = soundFolder.relativize(file);
             String dest = destination;
             dest += relative.toString();
 
-            //Remove the actual file name
-            dest = dest.substring(0, dest.length() - file.toPath().getFileName().toString().length());
+            // Remove the actual file name
+            dest = dest.substring(0, dest.length() - file.getFileName().toString().length());
 
-            //Extract
+            // Extract
             sdt.extractFileData(dest);
         }
     }

--- a/src/toniarts/openkeeper/tools/convert/TextureExtractor.java
+++ b/src/toniarts/openkeeper/tools/convert/TextureExtractor.java
@@ -16,7 +16,7 @@
  */
 package toniarts.openkeeper.tools.convert;
 
-import java.io.File;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import toniarts.openkeeper.tools.convert.textures.enginetextures.EngineTexturesFile;
@@ -33,7 +33,7 @@ public class TextureExtractor {
     public static void main(String[] args) {
 
         // Take Dungeon Keeper 2 root folder as parameter
-        if (args.length != 2 || !new File(args[1]).exists()) {
+        if (args.length != 2 || !Files.exists(Paths.get(args[1]))) {
             dkIIFolder = PathUtils.getDKIIFolder();
             if (dkIIFolder == null || args.length == 0)
             {

--- a/src/toniarts/openkeeper/tools/convert/TextureExtractor.java
+++ b/src/toniarts/openkeeper/tools/convert/TextureExtractor.java
@@ -17,6 +17,8 @@
 package toniarts.openkeeper.tools.convert;
 
 import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import toniarts.openkeeper.tools.convert.textures.enginetextures.EngineTexturesFile;
 import toniarts.openkeeper.utils.PathUtils;
 
@@ -30,7 +32,7 @@ public class TextureExtractor {
 
     public static void main(String[] args) {
 
-        //Take Dungeon Keeper 2 root folder as parameter
+        // Take Dungeon Keeper 2 root folder as parameter
         if (args.length != 2 || !new File(args[1]).exists()) {
             dkIIFolder = PathUtils.getDKIIFolder();
             if (dkIIFolder == null || args.length == 0)
@@ -41,13 +43,13 @@ public class TextureExtractor {
             dkIIFolder = PathUtils.fixFilePath(args[1]);
         }
 
-        final String cacheFolder = dkIIFolder.concat("DK2TextureCache").concat(File.separator);
+        final Path cacheFolder = Paths.get(dkIIFolder, "DK2TextureCache", "EngineTextures.dat");
 
         //And the destination
         String destination = PathUtils.fixFilePath(args[0]);
 
         //Extract the meshes
-        EngineTexturesFile etFile = new EngineTexturesFile(new File(cacheFolder + "EngineTextures.dat"));
+        EngineTexturesFile etFile = new EngineTexturesFile(cacheFolder);
         etFile.extractFileData(destination);
     }
 }

--- a/src/toniarts/openkeeper/tools/convert/WadExtractor.java
+++ b/src/toniarts/openkeeper/tools/convert/WadExtractor.java
@@ -17,7 +17,8 @@
 package toniarts.openkeeper.tools.convert;
 
 import java.io.File;
-
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import toniarts.openkeeper.tools.convert.wad.WadFile;
 import toniarts.openkeeper.utils.PathUtils;
 
@@ -32,7 +33,7 @@ public class WadExtractor {
 
     public static void main(String[] args) {
 
-        //Take Dungeon Keeper 2 root folder as parameter
+        // Take Dungeon Keeper 2 root folder as parameter
         if (args.length != 2 || !new File(args[1]).exists()) {
             dkIIFolder = PathUtils.getDKIIFolder();
             if (dkIIFolder == null || args.length == 0)
@@ -43,13 +44,13 @@ public class WadExtractor {
             dkIIFolder = PathUtils.fixFilePath(args[1]);
         }
 
-        final String dataFolder = dkIIFolder+ PathUtils.DKII_DATA_FOLDER;
+        final Path dataFolder = Paths.get(dkIIFolder, PathUtils.DKII_DATA_FOLDER, "Meshes.WAD");
 
-        //And the destination
+        // And the destination
         String destination = PathUtils.fixFilePath(args[0]);
 
-        //Extract the meshes
-        WadFile wad = new WadFile(new File(dataFolder + "Meshes.WAD"));
+        // Extract the meshes
+        WadFile wad = new WadFile(dataFolder);
         wad.extractFileData(destination.concat("meshes"));
     }
 }

--- a/src/toniarts/openkeeper/tools/convert/WadExtractor.java
+++ b/src/toniarts/openkeeper/tools/convert/WadExtractor.java
@@ -16,7 +16,7 @@
  */
 package toniarts.openkeeper.tools.convert;
 
-import java.io.File;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import toniarts.openkeeper.tools.convert.wad.WadFile;
@@ -34,7 +34,7 @@ public class WadExtractor {
     public static void main(String[] args) {
 
         // Take Dungeon Keeper 2 root folder as parameter
-        if (args.length != 2 || !new File(args[1]).exists()) {
+        if (args.length != 2 || !Files.exists(Paths.get(args[1]))) {
             dkIIFolder = PathUtils.getDKIIFolder();
             if (dkIIFolder == null || args.length == 0)
             {

--- a/src/toniarts/openkeeper/tools/convert/bf4/Bf4File.java
+++ b/src/toniarts/openkeeper/tools/convert/bf4/Bf4File.java
@@ -24,9 +24,9 @@ import java.awt.image.MultiPixelPackedSampleModel;
 import java.awt.image.Raster;
 import java.awt.image.WritableRaster;
 import java.io.ByteArrayInputStream;
-import java.io.File;
 import java.io.IOException;
 import java.nio.ByteOrder;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -71,7 +71,7 @@ public class Bf4File implements Iterable<Bf4Entry> {
      *
      * @param file the bf4 file to read
      */
-    public Bf4File(File file) {
+    public Bf4File(Path file) {
 
         // Read the file
         try (IResourceReader rawBf4 = new ResourceReader(file)) {

--- a/src/toniarts/openkeeper/tools/convert/bf4/Bf4File.java
+++ b/src/toniarts/openkeeper/tools/convert/bf4/Bf4File.java
@@ -34,7 +34,7 @@ import java.util.List;
 import javax.imageio.stream.MemoryCacheImageInputStream;
 import toniarts.openkeeper.tools.convert.IResourceChunkReader;
 import toniarts.openkeeper.tools.convert.IResourceReader;
-import toniarts.openkeeper.tools.convert.ResourceReader;
+import toniarts.openkeeper.tools.convert.FileResourceReader;
 import toniarts.openkeeper.tools.convert.bf4.Bf4Entry.FontEntryFlag;
 
 /**
@@ -74,7 +74,7 @@ public class Bf4File implements Iterable<Bf4Entry> {
     public Bf4File(Path file) {
 
         // Read the file
-        try (IResourceReader rawBf4 = new ResourceReader(file)) {
+        try (IResourceReader rawBf4 = new FileResourceReader(file)) {
 
             // Check the header
             IResourceChunkReader rawBf4Reader = rawBf4.readChunk(8);

--- a/src/toniarts/openkeeper/tools/convert/conversion/graph/TaskNode.java
+++ b/src/toniarts/openkeeper/tools/convert/conversion/graph/TaskNode.java
@@ -37,7 +37,7 @@ public class TaskNode extends Node<TaskNode> {
         this.executed = executed;
     }
 
-    public void executeTask() {
+    public void executeTask() throws Exception {
         task.getTask().executeTask();
 
         executed = true;

--- a/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertFonts.java
+++ b/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertFonts.java
@@ -23,6 +23,7 @@ import java.io.OutputStreamWriter;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
@@ -74,14 +75,14 @@ public class ConvertFonts extends ConversionTask {
             new File(destination).mkdirs();
 
             // Find all the font files
-            final List<File> bf4Files = new ArrayList<>();
-            Files.walkFileTree(new File(dungeonKeeperFolder + PathUtils.DKII_TEXT_DEFAULT_FOLDER).toPath(), new SimpleFileVisitor<Path>() {
+            final List<Path> bf4Files = new ArrayList<>();
+            Files.walkFileTree(Paths.get(dungeonKeeperFolder, PathUtils.DKII_TEXT_DEFAULT_FOLDER), new SimpleFileVisitor<Path>() {
                 @Override
                 public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
 
-                    //Get all the BF4 files
-                    if (attrs.isRegularFile() && file.getFileName().toString().toLowerCase().endsWith(".bf4")) {
-                        bf4Files.add(file.toFile());
+                    // Get all the BF4 files
+                    if (file.getFileName().toString().toLowerCase().endsWith(".bf4") && attrs.isRegularFile()) {
+                        bf4Files.add(file);
                     }
 
                     // Always continue
@@ -93,7 +94,7 @@ public class ConvertFonts extends ConversionTask {
             int i = 0;
             int total = bf4Files.size();
             Pattern pattern = Pattern.compile("FONT_(?<name>\\D+)(?<size>\\d+)", Pattern.CASE_INSENSITIVE);
-            for (File file : bf4Files) {
+            for (Path file : bf4Files) {
                 updateStatus(i, total);
 
                 // The file names
@@ -101,10 +102,10 @@ public class ConvertFonts extends ConversionTask {
 
                 final String imageFileName;
                 final String descriptionFileName;
-                Matcher matcher = pattern.matcher(file.getName());
+                Matcher matcher = pattern.matcher(file.getFileName().toString());
                 boolean found = matcher.find();
                 if (!found) {
-                    LOGGER.log(Level.SEVERE, "Font name {0} not recognized!", file.getName());
+                    LOGGER.log(Level.SEVERE, "Font name {0} not recognized!", file.getFileName());
                     throw new RuntimeException("Unknown font name!");
                 } else {
                     fontSize = Integer.parseInt(matcher.group("size"));

--- a/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertFonts.java
+++ b/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertFonts.java
@@ -67,12 +67,13 @@ public class ConvertFonts extends ConversionTask {
     private void convertFonts(final String dungeonKeeperFolder, final String destination) {
         LOGGER.log(Level.INFO, "Extracting fonts to: {0}", destination);
         updateStatus(null, null);
-        AssetUtils.deleteFolder(new File(destination));
+        Path destFolder = Paths.get(destination);
+        AssetUtils.deleteFolder(destFolder);
 
         try {
 
             // Make sure the folder exists
-            new File(destination).mkdirs();
+            Files.createDirectories(destFolder);
 
             // Find all the font files
             final List<Path> bf4Files = new ArrayList<>();

--- a/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertFonts.java
+++ b/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertFonts.java
@@ -16,15 +16,16 @@
  */
 package toniarts.openkeeper.tools.convert.conversion.task;
 
+import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.List;
@@ -129,8 +130,8 @@ public class ConvertFonts extends ConversionTask {
                     }
                 };
                 ImageIO.write(fc.getFontImage(), "png", new File(imageFileName));
-                try (OutputStreamWriter out = new OutputStreamWriter(new FileOutputStream(descriptionFileName))) {
-                    out.write(fc.getDescription());
+                try (BufferedWriter bw = Files.newBufferedWriter(Paths.get(descriptionFileName), StandardCharsets.UTF_8, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {
+                    bw.write(fc.getDescription());
                 }
 
                 i++;

--- a/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertHiScores.java
+++ b/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertHiScores.java
@@ -62,8 +62,9 @@ public class ConvertHiScores extends ConversionTask {
             // Convert it!
             HiScores hiScores = new HiScores();
             for (HiScoresEntry entry : originalHiScores.getHiScoresEntries()) {
-                hiScores.add(entry.getScore(), entry.getName(), entry.getLevel());
+                hiScores.addWithoutSaving(entry.getScore(), entry.getName(), entry.getLevel());
             }
+            hiScores.save();
             updateStatus(1, 1);
         } catch (Exception ex) {
             LOGGER.log(Level.WARNING, "Can not convert HiScores!", ex);

--- a/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertHiScores.java
+++ b/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertHiScores.java
@@ -16,11 +16,13 @@
  */
 package toniarts.openkeeper.tools.convert.conversion.task;
 
-import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import toniarts.openkeeper.game.data.HiScores;
 import toniarts.openkeeper.tools.convert.AssetsConverter;
+import toniarts.openkeeper.tools.convert.ConversionUtils;
 import toniarts.openkeeper.tools.convert.hiscores.HiScoresEntry;
 import toniarts.openkeeper.tools.convert.hiscores.HiScoresFile;
 
@@ -54,7 +56,7 @@ public class ConvertHiScores extends ConversionTask {
         try {
 
             // Load the original
-            File file = new File(dungeonKeeperFolder + "Data/Settings/HiScores.dat");
+            Path file = Paths.get(ConversionUtils.getRealFileName(dungeonKeeperFolder, "Data/Settings/HiScores.dat"));
             HiScoresFile originalHiScores = new HiScoresFile(file);
 
             // Convert it!

--- a/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertMapThumbnails.java
+++ b/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertMapThumbnails.java
@@ -65,11 +65,16 @@ public class ConvertMapThumbnails extends ConversionTask {
     private void generateMapThumbnails(String dungeonKeeperFolder, String destination) {
         LOGGER.log(Level.INFO, "Generating map thumbnails to: {0}", destination);
         updateStatus(null, null);
-        File destFolder = new File(destination);
+        Path destFolder = Paths.get(destination);
         AssetUtils.deleteFolder(destFolder);
 
-        // Make sure it exists
-        destFolder.mkdirs();
+        try {
+
+            // Make sure it exists
+            Files.createDirectories(destFolder);
+        } catch (IOException ex) {
+            throw new RuntimeException("Failed to create destination folder " + destFolder + "!", ex);
+        }
 
         // Get the skirmish/mp maps
         List<KwdFile> maps = new ArrayList<>();

--- a/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertModels.java
+++ b/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertModels.java
@@ -114,7 +114,7 @@ public class ConvertModels extends ConversionTask {
             try {
 
                 // See if we already have this model
-                if (!overwriteData && new File(destination.concat(entry.substring(0, entry.length() - 4)).concat(".j3o")).exists()) {
+                if (!overwriteData && Files.exists(Paths.get(destination, entry.substring(0, entry.length() - 4).concat(".j3o")))) {
                     LOGGER.log(Level.INFO, "File {0} already exists, skipping!", entry);
                     updateStatus(progress.incrementAndGet(), total);
                     continue;

--- a/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertModels.java
+++ b/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertModels.java
@@ -88,12 +88,16 @@ public class ConvertModels extends ConversionTask {
     private void convertModels(String dungeonKeeperFolder, String destination, AssetManager assetManager) {
         LOGGER.log(Level.INFO, "Extracting models to: {0}", destination);
         updateStatus(null, null);
-        AssetUtils.deleteFolder(new File(destination));
+        AssetUtils.deleteFolder(Paths.get(destination));
 
         // Create the materials folder or else the material file saving fails
-        File materialFolder = new File(getAssetsFolder().concat(AssetsConverter.MATERIALS_FOLDER));
+        Path materialFolder = Paths.get(getAssetsFolder(), AssetsConverter.MATERIALS_FOLDER);
         AssetUtils.deleteFolder(materialFolder);
-        materialFolder.mkdirs();
+        try {
+            Files.createDirectories(materialFolder);
+        } catch (IOException ex) {
+            throw new RuntimeException("Failed to create destination folder " + materialFolder + "!", ex);
+        }
 
         // Meshes are in the data folder, access the packed file
         WadFile wad;

--- a/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertMouseCursors.java
+++ b/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertMouseCursors.java
@@ -17,11 +17,16 @@
 package toniarts.openkeeper.tools.convert.conversion.task;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import toniarts.openkeeper.tools.convert.AssetsConverter;
 import static toniarts.openkeeper.tools.convert.AssetsConverter.SPRITES_FOLDER;
 import static toniarts.openkeeper.tools.convert.AssetsConverter.getAssetsFolder;
+import toniarts.openkeeper.tools.convert.ConversionUtils;
 import toniarts.openkeeper.tools.convert.spr.SprFile;
 import toniarts.openkeeper.tools.convert.wad.WadFile;
 import toniarts.openkeeper.utils.AssetUtils;
@@ -58,7 +63,12 @@ public class ConvertMouseCursors extends ConversionTask {
         AssetUtils.deleteFolder(new File(destination));
 
         // Mouse cursors are PNG files in the Sprite.WAD
-        WadFile wadFile = new WadFile(new File(dungeonKeeperFolder + PathUtils.DKII_DATA_FOLDER + "Sprite.WAD"));
+        WadFile wadFile;
+        try {
+            wadFile = new WadFile(Paths.get(ConversionUtils.getRealFileName(dungeonKeeperFolder + PathUtils.DKII_DATA_FOLDER, "Sprite.WAD")));
+        } catch (IOException ex) {
+            throw new RuntimeException("Could not open the Sprite.wad archive!", ex);
+        }
         int i = 0;
         int total = wadFile.getWadFileEntryCount();
         File destinationFolder = new File(getAssetsFolder().concat(SPRITES_FOLDER).concat(File.separator));
@@ -70,7 +80,7 @@ public class ConvertMouseCursors extends ConversionTask {
             i++;
 
             // Extract the file
-            File extracted = wadFile.extractFileData(fileName, destination);
+            Path extracted = wadFile.extractFileData(fileName, destination);
 
             if (fileName.toLowerCase().endsWith(".spr")) {
 
@@ -78,7 +88,7 @@ public class ConvertMouseCursors extends ConversionTask {
                 SprFile sprFile = new SprFile(extracted);
                 try {
                     sprFile.extract(destinationFolder.getPath(), fileName.substring(0, fileName.length() - 4));
-                    extracted.delete();
+                    Files.delete(extracted);
                 } catch (Exception ex) {
                     LOGGER.log(Level.SEVERE, "Error Sprite: {0}", ex);
                 }

--- a/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertMouseCursors.java
+++ b/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertMouseCursors.java
@@ -83,19 +83,19 @@ public class ConvertMouseCursors extends ConversionTask {
             updateStatus(i, total);
             i++;
 
-            // Extract the file
-            Path extracted = wadFile.extractFileData(fileName, destination);
-
             if (fileName.toLowerCase().endsWith(".spr")) {
 
                 // Extract the spr and delete it afterwards
-                SprFile sprFile = new SprFile(extracted);
+                SprFile sprFile = new SprFile(wadFile.getFileData(fileName));
                 try {
                     sprFile.extract(destinationFolderAsString, fileName.substring(0, fileName.length() - 4));
-                    Files.delete(extracted);
                 } catch (Exception ex) {
                     LOGGER.log(Level.SEVERE, "Error Sprite: {0}", ex);
                 }
+            } else {
+
+                // Extract the file
+                wadFile.extractFileData(fileName, destination);
             }
         }
     }

--- a/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertMouseCursors.java
+++ b/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertMouseCursors.java
@@ -16,7 +16,6 @@
  */
 package toniarts.openkeeper.tools.convert.conversion.task;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -60,7 +59,7 @@ public class ConvertMouseCursors extends ConversionTask {
     private void convertMouseCursors(String dungeonKeeperFolder, String destination) {
         LOGGER.log(Level.INFO, "Extracting mouse cursors to: {0}", destination);
         updateStatus(null, null);
-        AssetUtils.deleteFolder(new File(destination));
+        AssetUtils.deleteFolder(Paths.get(destination));
 
         // Mouse cursors are PNG files in the Sprite.WAD
         WadFile wadFile;
@@ -71,9 +70,14 @@ public class ConvertMouseCursors extends ConversionTask {
         }
         int i = 0;
         int total = wadFile.getWadFileEntryCount();
-        File destinationFolder = new File(getAssetsFolder().concat(SPRITES_FOLDER).concat(File.separator));
+        Path destinationFolder = Paths.get(getAssetsFolder(), SPRITES_FOLDER);
         AssetUtils.deleteFolder(destinationFolder);
-        destinationFolder.mkdirs();
+        try {
+            Files.createDirectories(destinationFolder);
+        } catch (IOException ex) {
+            throw new RuntimeException("Failed to create destination folder " + destinationFolder + "!", ex);
+        }
+        String destinationFolderAsString = destinationFolder.toString();
 
         for (String fileName : wadFile.getWadFileEntries()) {
             updateStatus(i, total);
@@ -87,7 +91,7 @@ public class ConvertMouseCursors extends ConversionTask {
                 // Extract the spr and delete it afterwards
                 SprFile sprFile = new SprFile(extracted);
                 try {
-                    sprFile.extract(destinationFolder.getPath(), fileName.substring(0, fileName.length() - 4));
+                    sprFile.extract(destinationFolderAsString, fileName.substring(0, fileName.length() - 4));
                     Files.delete(extracted);
                 } catch (Exception ex) {
                     LOGGER.log(Level.SEVERE, "Error Sprite: {0}", ex);

--- a/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertPaths.java
+++ b/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertPaths.java
@@ -79,7 +79,7 @@ public class ConvertPaths extends ConversionTask {
         }
         int i = 0;
         int total = wad.getWadFileEntryCount();
-        File tmpdir = new File(System.getProperty("java.io.tmpdir"));
+        String tmpdir = System.getProperty("java.io.tmpdir");
         BinaryExporter exporter = BinaryExporter.getInstance();
         for (final String entry : wad.getWadFileEntries()) {
             try {
@@ -90,7 +90,7 @@ public class ConvertPaths extends ConversionTask {
                 if (entry.toLowerCase().endsWith(".kcs")) {
 
                     // Extract each file to temp
-                    Path f = wad.extractFileData(entry, tmpdir.toString());
+                    Path f = wad.extractFileData(entry, tmpdir);
                     f.toFile().deleteOnExit();
 
                     // Open the entry

--- a/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertPaths.java
+++ b/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertPaths.java
@@ -68,7 +68,7 @@ public class ConvertPaths extends ConversionTask {
     private void convertPaths(String dungeonKeeperFolder, String destination) {
         LOGGER.log(Level.INFO, "Extracting paths to: {0}", destination);
         updateStatus(null, null);
-        AssetUtils.deleteFolder(new File(destination));
+        AssetUtils.deleteFolder(Paths.get(destination));
 
         // Paths are in the data folder, access the packed file
         WadFile wad;

--- a/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertPaths.java
+++ b/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertPaths.java
@@ -87,7 +87,6 @@ public class ConvertPaths extends ConversionTask {
         }
         int i = 0;
         int total = wad.getWadFileEntryCount();
-        String tmpdir = System.getProperty("java.io.tmpdir");
         BinaryExporter exporter = BinaryExporter.getInstance();
         for (final String entry : wad.getWadFileEntries()) {
             try {
@@ -97,12 +96,8 @@ public class ConvertPaths extends ConversionTask {
                 // Convert all the KCS entries
                 if (entry.toLowerCase().endsWith(".kcs")) {
 
-                    // Extract each file to temp
-                    Path f = wad.extractFileData(entry, tmpdir);
-                    f.toFile().deleteOnExit();
-
                     // Open the entry
-                    KcsFile kcsFile = new KcsFile(f);
+                    KcsFile kcsFile = new KcsFile(wad.getFileData(entry));
 
                     // Convert
                     List<CameraSweepDataEntry> entries = new ArrayList<>(kcsFile.getKcsEntries().size());

--- a/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertPaths.java
+++ b/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertPaths.java
@@ -22,6 +22,9 @@ import com.jme3.math.Matrix3f;
 import com.jme3.math.Quaternion;
 import com.jme3.math.Vector3f;
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
@@ -68,7 +71,12 @@ public class ConvertPaths extends ConversionTask {
         AssetUtils.deleteFolder(new File(destination));
 
         // Paths are in the data folder, access the packed file
-        WadFile wad = new WadFile(new File(dungeonKeeperFolder + PathUtils.DKII_DATA_FOLDER + "Paths.WAD"));
+        WadFile wad;
+        try {
+            wad = new WadFile(Paths.get(ConversionUtils.getRealFileName(dungeonKeeperFolder + PathUtils.DKII_DATA_FOLDER, "Paths.WAD")));
+        } catch (IOException ex) {
+            throw new RuntimeException("Failed to open the Paths.wad archive!", ex);
+        }
         int i = 0;
         int total = wad.getWadFileEntryCount();
         File tmpdir = new File(System.getProperty("java.io.tmpdir"));
@@ -82,8 +90,8 @@ public class ConvertPaths extends ConversionTask {
                 if (entry.toLowerCase().endsWith(".kcs")) {
 
                     // Extract each file to temp
-                    File f = wad.extractFileData(entry, tmpdir.toString());
-                    f.deleteOnExit();
+                    Path f = wad.extractFileData(entry, tmpdir.toString());
+                    f.toFile().deleteOnExit();
 
                     // Open the entry
                     KcsFile kcsFile = new KcsFile(f);

--- a/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertSounds.java
+++ b/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertSounds.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
@@ -61,7 +62,7 @@ public class ConvertSounds extends ConversionTask {
     private void convertSounds(String dungeonKeeperFolder, String destination) {
         LOGGER.log(Level.INFO, "Extracting sounds to: {0}", destination);
         updateStatus(null, null);
-        AssetUtils.deleteFolder(new File(destination));
+        AssetUtils.deleteFolder(Paths.get(destination));
         String dataDirectory = PathUtils.DKII_SFX_FOLDER;
 
         // Find all the sound files
@@ -99,8 +100,8 @@ public class ConvertSounds extends ConversionTask {
             SdtFile sdt = new SdtFile(file);
 
             // Get a relative path
-            String path = file.toString().substring(0, file.toString().length() - 4);
-            Path relative = dataDir.toPath().relativize(new File(path).toPath());
+            Path path = Paths.get(file.toString().substring(0, file.toString().length() - 4));
+            Path relative = dataDir.toPath().relativize(path);
             String dest = destination;
             dest += relative.toString();
 

--- a/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertSounds.java
+++ b/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertSounds.java
@@ -16,7 +16,6 @@
  */
 package toniarts.openkeeper.tools.convert.conversion.task;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
@@ -67,10 +66,10 @@ public class ConvertSounds extends ConversionTask {
 
         // Find all the sound files
         final List<Path> sdtFiles = new ArrayList<>();
-        File dataDir = null;
+        Path dataDir = null;
         try {
-            dataDir = new File(ConversionUtils.getRealFileName(dungeonKeeperFolder, dataDirectory));
-            Files.walkFileTree(dataDir.toPath(), new SimpleFileVisitor<Path>() {
+            dataDir = Paths.get(ConversionUtils.getRealFileName(dungeonKeeperFolder, dataDirectory));
+            Files.walkFileTree(dataDir, new SimpleFileVisitor<Path>() {
                 @Override
                 public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
 
@@ -101,7 +100,7 @@ public class ConvertSounds extends ConversionTask {
 
             // Get a relative path
             Path path = Paths.get(file.toString().substring(0, file.toString().length() - 4));
-            Path relative = dataDir.toPath().relativize(path);
+            Path relative = dataDir.relativize(path);
             String dest = destination;
             dest += relative.toString();
 

--- a/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertSounds.java
+++ b/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertSounds.java
@@ -65,7 +65,7 @@ public class ConvertSounds extends ConversionTask {
         String dataDirectory = PathUtils.DKII_SFX_FOLDER;
 
         // Find all the sound files
-        final List<File> sdtFiles = new ArrayList<>();
+        final List<Path> sdtFiles = new ArrayList<>();
         File dataDir = null;
         try {
             dataDir = new File(ConversionUtils.getRealFileName(dungeonKeeperFolder, dataDirectory));
@@ -73,12 +73,12 @@ public class ConvertSounds extends ConversionTask {
                 @Override
                 public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
 
-                    //Get all the SDT files
-                    if (attrs.isRegularFile() && file.getFileName().toString().toLowerCase().endsWith(".sdt")) {
-                        sdtFiles.add(file.toFile());
+                    // Get all the SDT files
+                    if (file.getFileName().toString().toLowerCase().endsWith(".sdt") && attrs.isRegularFile()) {
+                        sdtFiles.add(file);
                     }
 
-                    //Always continue
+                    // Always continue
                     return FileVisitResult.CONTINUE;
                 }
             });
@@ -92,21 +92,21 @@ public class ConvertSounds extends ConversionTask {
         // FIXME: We should try to figure out the map files, but at least merge the sound track files
         int i = 0;
         int total = sdtFiles.size();
-        for (File file : sdtFiles) {
+        for (Path file : sdtFiles) {
             updateStatus(i, total);
             i++;
 
             SdtFile sdt = new SdtFile(file);
 
-            //Get a relative path
+            // Get a relative path
             String path = file.toString().substring(0, file.toString().length() - 4);
             Path relative = dataDir.toPath().relativize(new File(path).toPath());
             String dest = destination;
             dest += relative.toString();
 
-            //Remove the actual file name
+            // Remove the actual file name
             //dest = dest.substring(0, dest.length() - file.toPath().getFileName().toString().length());
-            //Extract
+            // Extract
             sdt.extractFileData(dest);
         }
     }

--- a/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertTexts.java
+++ b/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertTexts.java
@@ -16,16 +16,17 @@
  */
 package toniarts.openkeeper.tools.convert.conversion.task;
 
+import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStreamWriter;
-import java.io.PrintWriter;
+import java.nio.charset.Charset;
 import java.nio.file.FileVisitOption;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.EnumSet;
@@ -71,19 +72,19 @@ public class ConvertTexts extends ConversionTask {
         String dataDirectory = dungeonKeeperFolder + PathUtils.DKII_TEXT_DEFAULT_FOLDER;
 
         // Find all the STR files
-        final List<File> srtFiles = new ArrayList<>();
+        final List<Path> srtFiles = new ArrayList<>();
         File dataDir = new File(dataDirectory);
         try {
             Files.walkFileTree(dataDir.toPath(), EnumSet.noneOf(FileVisitOption.class), 1, new SimpleFileVisitor<Path>() {
                 @Override
                 public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
 
-                    //Get all the STR files
-                    if (attrs.isRegularFile() && file.getFileName().toString().toLowerCase().endsWith(".str")) {
-                        srtFiles.add(file.toFile());
+                    // Get all the STR files
+                    if (file.getFileName().toString().toLowerCase().endsWith(".str") && attrs.isRegularFile()) {
+                        srtFiles.add(file);
                     }
 
-                    //Always continue
+                    // Always continue
                     return FileVisitResult.CONTINUE;
                 }
             });
@@ -98,7 +99,7 @@ public class ConvertTexts extends ConversionTask {
         int i = 0;
         int total = srtFiles.size();
         MbToUniFile codePage = null;
-        for (File file : srtFiles) {
+        for (Path file : srtFiles) {
             updateStatus(i, total);
             i++;
 
@@ -112,12 +113,15 @@ public class ConvertTexts extends ConversionTask {
             }
 
             // Write the properties
-            String fileName = file.getName();
+            String fileName = file.getFileName().toString();
             fileName = fileName.substring(0, fileName.length() - 3);
-            File dictFile = new File(destination.concat(fileName).concat("properties"));
-            try (PrintWriter pw = new PrintWriter(new OutputStreamWriter(new FileOutputStream(dictFile, false), "UTF-8"))) {
+            Path dictFile = Paths.get(destination, fileName + "properties");
+            try (BufferedWriter bw = Files.newBufferedWriter(dictFile, Charset.forName("UTF-8"), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {
                 for (Map.Entry<Integer, String> entry : strFile.getEntriesAsSet()) {
-                    pw.println(entry.getKey() + "=" + entry.getValue());
+                    bw.write(entry.getKey().toString());
+                    bw.write("=");
+                    bw.write(entry.getValue());
+                    bw.newLine();
                 }
             } catch (IOException ex) {
                 String msg = "Failed to save the dictionary file to " + dictFile + "!";

--- a/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertTexts.java
+++ b/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertTexts.java
@@ -19,7 +19,7 @@ package toniarts.openkeeper.tools.convert.conversion.task;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileVisitOption;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
@@ -116,7 +116,7 @@ public class ConvertTexts extends ConversionTask {
             String fileName = file.getFileName().toString();
             fileName = fileName.substring(0, fileName.length() - 3);
             Path dictFile = Paths.get(destination, fileName + "properties");
-            try (BufferedWriter bw = Files.newBufferedWriter(dictFile, Charset.forName("UTF-8"), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {
+            try (BufferedWriter bw = Files.newBufferedWriter(dictFile, StandardCharsets.UTF_8, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {
                 for (Map.Entry<Integer, String> entry : strFile.getEntriesAsSet()) {
                     bw.write(entry.getKey().toString());
                     bw.write("=");

--- a/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertTexts.java
+++ b/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertTexts.java
@@ -68,7 +68,8 @@ public class ConvertTexts extends ConversionTask {
     private void convertTexts(String dungeonKeeperFolder, String destination) {
         LOGGER.log(Level.INFO, "Extracting texts to: {0}", destination);
         updateStatus(null, null);
-        AssetUtils.deleteFolder(new File(destination));
+        Path destinationFolder = Paths.get(destination);
+        AssetUtils.deleteFolder(destinationFolder);
         String dataDirectory = dungeonKeeperFolder + PathUtils.DKII_TEXT_DEFAULT_FOLDER;
 
         // Find all the STR files
@@ -95,7 +96,11 @@ public class ConvertTexts extends ConversionTask {
         }
 
         // Convert the STR files to JAVA native resource bundles
-        new File(destination).mkdirs(); // Ensure that the folder exists
+        try {
+            Files.createDirectories(destinationFolder);
+        } catch (IOException ex) {
+            throw new RuntimeException("Failed to create destination folder " + destinationFolder + "!", ex);
+        }
         int i = 0;
         int total = srtFiles.size();
         MbToUniFile codePage = null;

--- a/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertTexts.java
+++ b/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertTexts.java
@@ -17,7 +17,6 @@
 package toniarts.openkeeper.tools.convert.conversion.task;
 
 import java.io.BufferedWriter;
-import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileVisitOption;
@@ -70,13 +69,12 @@ public class ConvertTexts extends ConversionTask {
         updateStatus(null, null);
         Path destinationFolder = Paths.get(destination);
         AssetUtils.deleteFolder(destinationFolder);
-        String dataDirectory = dungeonKeeperFolder + PathUtils.DKII_TEXT_DEFAULT_FOLDER;
+        Path dataDirectory = Paths.get(dungeonKeeperFolder, PathUtils.DKII_TEXT_DEFAULT_FOLDER);
 
         // Find all the STR files
         final List<Path> srtFiles = new ArrayList<>();
-        File dataDir = new File(dataDirectory);
         try {
-            Files.walkFileTree(dataDir.toPath(), EnumSet.noneOf(FileVisitOption.class), 1, new SimpleFileVisitor<Path>() {
+            Files.walkFileTree(dataDirectory, EnumSet.noneOf(FileVisitOption.class), 1, new SimpleFileVisitor<Path>() {
                 @Override
                 public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
 

--- a/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertTextures.java
+++ b/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertTextures.java
@@ -157,6 +157,7 @@ public class ConvertTextures extends ConversionTask {
                     }
                     Files.move(f, newFile);
                 } catch (IOException ex) {
+                    LOGGER.log(Level.SEVERE, "Failed to handle " + textureFile + "!", ex);
                     throw new RuntimeException("Failed to handle " + textureFile + "!", ex);
                 }
             } else if (!found) {
@@ -183,11 +184,11 @@ public class ConvertTextures extends ConversionTask {
             if (entry.endsWith(".444")) {
                 LoadingScreenFile lsf = new LoadingScreenFile(wad.getFileData(entry));
                 try {
-                    Path destFile = Paths.get(destination, entry);
-                    String destFilename = destFile.toRealPath().toString();
+                    Path destFile = Paths.get(destination, entry.substring(0, entry.length() - 3).concat("png"));
                     Files.createDirectories(destFile.getParent());
-                    ImageIO.write(lsf.getImage(), "png", new File(destFilename.substring(0, destFilename.length() - 3).concat("png")));
+                    ImageIO.write(lsf.getImage(), "png", destFile.toFile());
                 } catch (IOException ex) {
+                    LOGGER.log(Level.SEVERE, "Failed to save the wad entry " + entry + "!", ex);
                     throw new RuntimeException("Failed to save the wad entry " + entry + "!", ex);
                 }
             } else {

--- a/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertTextures.java
+++ b/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertTextures.java
@@ -16,8 +16,8 @@
  */
 package toniarts.openkeeper.tools.convert.conversion.task;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -125,7 +125,7 @@ public class ConvertTextures extends ConversionTask {
 
         // Get the engine textures file
         try {
-            EngineTexturesFile etFile = new EngineTexturesFile(Paths.get(ConversionUtils.getRealFileName(dungeonKeeperFolder, "DK2TextureCache".concat(File.separator).concat("EngineTextures.dat"))));
+            EngineTexturesFile etFile = new EngineTexturesFile(Paths.get(ConversionUtils.getRealFileName(dungeonKeeperFolder, "DK2TextureCache".concat(FileSystems.getDefault().getSeparator()).concat("EngineTextures.dat"))));
             return etFile;
         } catch (IOException e) {
             throw new RuntimeException("Failed to open the EngineTextures file!", e);

--- a/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertTextures.java
+++ b/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertTextures.java
@@ -183,9 +183,9 @@ public class ConvertTextures extends ConversionTask {
             if (entry.endsWith(".444")) {
                 LoadingScreenFile lsf = new LoadingScreenFile(wad.getFileData(entry));
                 try {
-                    File destFile = new File(destination + entry);
-                    String destFilename = destFile.getCanonicalPath();
-                    destFile.getParentFile().mkdirs();
+                    Path destFile = Paths.get(destination, entry);
+                    String destFilename = destFile.toRealPath().toString();
+                    Files.createDirectories(destFile.getParent());
                     ImageIO.write(lsf.getImage(), "png", new File(destFilename.substring(0, destFilename.length() - 3).concat("png")));
                 } catch (IOException ex) {
                     throw new RuntimeException("Failed to save the wad entry " + entry + "!", ex);

--- a/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertTextures.java
+++ b/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertTextures.java
@@ -18,6 +18,7 @@ package toniarts.openkeeper.tools.convert.conversion.task;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
@@ -82,8 +83,8 @@ public class ConvertTextures extends ConversionTask {
         WadFile frontEnd;
         WadFile engineTextures;
         try {
-            frontEnd = new WadFile(new File(ConversionUtils.getRealFileName(dungeonKeeperFolder, PathUtils.DKII_DATA_FOLDER + "FrontEnd.WAD")));
-            engineTextures = new WadFile(new File(ConversionUtils.getRealFileName(dungeonKeeperFolder, PathUtils.DKII_DATA_FOLDER + "EngineTextures.WAD")));
+            frontEnd = new WadFile(Paths.get(ConversionUtils.getRealFileName(dungeonKeeperFolder + PathUtils.DKII_DATA_FOLDER, "FrontEnd.WAD")));
+            engineTextures = new WadFile(Paths.get(ConversionUtils.getRealFileName(dungeonKeeperFolder + PathUtils.DKII_DATA_FOLDER, "EngineTextures.WAD")));
         } catch (IOException e) {
             throw new RuntimeException("Failed to open a WAD file!", e);
         }
@@ -120,7 +121,7 @@ public class ConvertTextures extends ConversionTask {
 
         // Get the engine textures file
         try {
-            EngineTexturesFile etFile = new EngineTexturesFile(new File(ConversionUtils.getRealFileName(dungeonKeeperFolder, "DK2TextureCache".concat(File.separator).concat("EngineTextures.dat"))));
+            EngineTexturesFile etFile = new EngineTexturesFile(Paths.get(ConversionUtils.getRealFileName(dungeonKeeperFolder, "DK2TextureCache".concat(File.separator).concat("EngineTextures.dat"))));
             return etFile;
         } catch (IOException e) {
             throw new RuntimeException("Failed to open the EngineTextures file!", e);

--- a/src/toniarts/openkeeper/tools/convert/conversion/task/IConversionTask.java
+++ b/src/toniarts/openkeeper/tools/convert/conversion/task/IConversionTask.java
@@ -23,7 +23,7 @@ package toniarts.openkeeper.tools.convert.conversion.task;
  */
 public interface IConversionTask {
 
-    public void executeTask();
+    public void executeTask() throws Exception;
 
     public void addListener(IConversionTaskUpdate listener);
 

--- a/src/toniarts/openkeeper/tools/convert/hiscores/HiScoresFile.java
+++ b/src/toniarts/openkeeper/tools/convert/hiscores/HiScoresFile.java
@@ -16,8 +16,8 @@
  */
 package toniarts.openkeeper.tools.convert.hiscores;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import toniarts.openkeeper.tools.convert.IResourceChunkReader;
@@ -40,7 +40,7 @@ public class HiScoresFile {
      *
      * @param file the HiScores file to read
      */
-    public HiScoresFile(File file) {
+    public HiScoresFile(Path file) {
 
         // Read the file
         try (IResourceReader data = new ResourceReader(file)) {

--- a/src/toniarts/openkeeper/tools/convert/hiscores/HiScoresFile.java
+++ b/src/toniarts/openkeeper/tools/convert/hiscores/HiScoresFile.java
@@ -22,7 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import toniarts.openkeeper.tools.convert.IResourceChunkReader;
 import toniarts.openkeeper.tools.convert.IResourceReader;
-import toniarts.openkeeper.tools.convert.ResourceReader;
+import toniarts.openkeeper.tools.convert.FileResourceReader;
 
 /**
  * Stores the HiScores file entries<br>
@@ -43,7 +43,7 @@ public class HiScoresFile {
     public HiScoresFile(Path file) {
 
         // Read the file
-        try (IResourceReader data = new ResourceReader(file)) {
+        try (IResourceReader data = new FileResourceReader(file)) {
 
             // Read the entries, no header, just entries till the end
             IResourceChunkReader reader = data.readAll();

--- a/src/toniarts/openkeeper/tools/convert/kcs/KcsFile.java
+++ b/src/toniarts/openkeeper/tools/convert/kcs/KcsFile.java
@@ -22,7 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import toniarts.openkeeper.tools.convert.IResourceChunkReader;
 import toniarts.openkeeper.tools.convert.IResourceReader;
-import toniarts.openkeeper.tools.convert.ResourceReader;
+import toniarts.openkeeper.tools.convert.FileResourceReader;
 
 /**
  * Stores the KCS file entries<br>
@@ -49,7 +49,7 @@ public class KcsFile {
     public KcsFile(Path file) {
 
         // Read the file
-        try (IResourceReader rawKcs = new ResourceReader(file)) {
+        try (IResourceReader rawKcs = new FileResourceReader(file)) {
 
             // Header
             IResourceChunkReader rawKcsReader = rawKcs.readChunk(4);

--- a/src/toniarts/openkeeper/tools/convert/kcs/KcsFile.java
+++ b/src/toniarts/openkeeper/tools/convert/kcs/KcsFile.java
@@ -20,9 +20,10 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import toniarts.openkeeper.tools.convert.ByteArrayResourceReader;
+import toniarts.openkeeper.tools.convert.FileResourceReader;
 import toniarts.openkeeper.tools.convert.IResourceChunkReader;
 import toniarts.openkeeper.tools.convert.IResourceReader;
-import toniarts.openkeeper.tools.convert.FileResourceReader;
 
 /**
  * Stores the KCS file entries<br>
@@ -38,7 +39,7 @@ import toniarts.openkeeper.tools.convert.FileResourceReader;
  */
 public class KcsFile {
 
-    private final List<KcsEntry> kcsEntries;
+    private List<KcsEntry> kcsEntries;
 
     /**
      * Constructs a new Kcs file reader<br>
@@ -50,31 +51,47 @@ public class KcsFile {
 
         // Read the file
         try (IResourceReader rawKcs = new FileResourceReader(file)) {
-
-            // Header
-            IResourceChunkReader rawKcsReader = rawKcs.readChunk(4);
-            int numOfEntries = rawKcsReader.readUnsignedInteger();
-            rawKcs.skipBytes(12); // 12 bytes of emptiness?
-
-            // Read the entries
-            rawKcsReader = rawKcs.readChunk(numOfEntries * 56);
-            kcsEntries = new ArrayList<>(numOfEntries);
-            for (int i = 0; i < numOfEntries; i++) {
-
-                // Entries have 56 bytes in them
-                KcsEntry entry = new KcsEntry();
-                entry.setPosition(rawKcsReader.readFloat(), rawKcsReader.readFloat(), rawKcsReader.readFloat());
-                entry.setDirection(rawKcsReader.readFloat(), rawKcsReader.readFloat(), rawKcsReader.readFloat());
-                entry.setLeft(rawKcsReader.readFloat(), rawKcsReader.readFloat(), rawKcsReader.readFloat());
-                entry.setUp(rawKcsReader.readFloat(), rawKcsReader.readFloat(), rawKcsReader.readFloat());
-                entry.setLens(rawKcsReader.readFloat());
-                entry.setNear(rawKcsReader.readFloat());
-                kcsEntries.add(entry);
-            }
+            parseKcsFile(rawKcs);
         } catch (IOException e) {
 
-            //Fug
+            // Fug
             throw new RuntimeException("Failed to open the file " + file + "!", e);
+        }
+    }
+
+    public KcsFile(byte[] data) {
+
+        // Read the file
+        try (IResourceReader rawKcs = new ByteArrayResourceReader(data)) {
+            parseKcsFile(rawKcs);
+        } catch (Exception e) {
+
+            // Fug
+            throw new RuntimeException("Failed to parse KCS data!", e);
+        }
+    }
+
+    private void parseKcsFile(final IResourceReader rawKcs) throws IOException {
+
+        // Header
+        IResourceChunkReader rawKcsReader = rawKcs.readChunk(4);
+        int numOfEntries = rawKcsReader.readUnsignedInteger();
+        rawKcs.skipBytes(12); // 12 bytes of emptiness?
+
+        // Read the entries
+        rawKcsReader = rawKcs.readChunk(numOfEntries * 56);
+        kcsEntries = new ArrayList<>(numOfEntries);
+        for (int i = 0; i < numOfEntries; i++) {
+
+            // Entries have 56 bytes in them
+            KcsEntry entry = new KcsEntry();
+            entry.setPosition(rawKcsReader.readFloat(), rawKcsReader.readFloat(), rawKcsReader.readFloat());
+            entry.setDirection(rawKcsReader.readFloat(), rawKcsReader.readFloat(), rawKcsReader.readFloat());
+            entry.setLeft(rawKcsReader.readFloat(), rawKcsReader.readFloat(), rawKcsReader.readFloat());
+            entry.setUp(rawKcsReader.readFloat(), rawKcsReader.readFloat(), rawKcsReader.readFloat());
+            entry.setLens(rawKcsReader.readFloat());
+            entry.setNear(rawKcsReader.readFloat());
+            kcsEntries.add(entry);
         }
     }
 

--- a/src/toniarts/openkeeper/tools/convert/kcs/KcsFile.java
+++ b/src/toniarts/openkeeper/tools/convert/kcs/KcsFile.java
@@ -16,8 +16,8 @@
  */
 package toniarts.openkeeper.tools.convert.kcs;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import toniarts.openkeeper.tools.convert.IResourceChunkReader;
@@ -46,7 +46,7 @@ public class KcsFile {
      *
      * @param file the kcs file to read
      */
-    public KcsFile(File file) {
+    public KcsFile(Path file) {
 
         // Read the file
         try (IResourceReader rawKcs = new ResourceReader(file)) {

--- a/src/toniarts/openkeeper/tools/convert/kmf/KmfFile.java
+++ b/src/toniarts/openkeeper/tools/convert/kmf/KmfFile.java
@@ -100,7 +100,7 @@ public class KmfFile {
         // Read the file
         try (IResourceReader rawKmf = new ByteArrayResourceReader(data)) {
             parseKmfFile(rawKmf);
-        } catch (IOException e) {
+        } catch (Exception e) {
 
             // Fug
             throw new RuntimeException("Failed to parse KMF data!", e);

--- a/src/toniarts/openkeeper/tools/convert/kmf/KmfFile.java
+++ b/src/toniarts/openkeeper/tools/convert/kmf/KmfFile.java
@@ -24,7 +24,7 @@ import java.util.List;
 import javax.vecmath.Vector3f;
 import toniarts.openkeeper.tools.convert.IResourceChunkReader;
 import toniarts.openkeeper.tools.convert.IResourceReader;
-import toniarts.openkeeper.tools.convert.ResourceReader;
+import toniarts.openkeeper.tools.convert.FileResourceReader;
 
 /**
  * Reads Dungeon Keeper II model file to a data structure<br>
@@ -85,7 +85,7 @@ public class KmfFile {
     public KmfFile(Path file) {
 
         // Read the file
-        try (IResourceReader rawKmf = new ResourceReader(file)) {
+        try (IResourceReader rawKmf = new FileResourceReader(file)) {
 
             IResourceChunkReader rawKmfReader = rawKmf.readChunk(28);
 

--- a/src/toniarts/openkeeper/tools/convert/kmf/KmfFile.java
+++ b/src/toniarts/openkeeper/tools/convert/kmf/KmfFile.java
@@ -16,8 +16,8 @@
  */
 package toniarts.openkeeper.tools.convert.kmf;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -82,7 +82,7 @@ public class KmfFile {
     private static final String KMF_GROP = "GROP";
     private static final String KMF_GROP_ELEM = "ELEM";
 
-    public KmfFile(File file) {
+    public KmfFile(Path file) {
 
         // Read the file
         try (IResourceReader rawKmf = new ResourceReader(file)) {

--- a/src/toniarts/openkeeper/tools/convert/map/KwdFile.java
+++ b/src/toniarts/openkeeper/tools/convert/map/KwdFile.java
@@ -17,8 +17,9 @@
 package toniarts.openkeeper.tools.convert.map;
 
 import java.awt.Color;
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -141,7 +142,7 @@ public final class KwdFile {
      * @param basePath path to DK II main path (or where ever is the "root")
      * @param file the KWD file to read
      */
-    public KwdFile(String basePath, File file) {
+    public KwdFile(String basePath, Path file) {
         this(basePath, file, true);
     }
 
@@ -153,7 +154,7 @@ public final class KwdFile {
      * @param load whether to actually load the map data, or just get the
      * general info
      */
-    public KwdFile(String basePath, File file, boolean load) {
+    public KwdFile(String basePath, Path file, boolean load) {
 
         // Load the actual main map info (paths to catalogs most importantly)
         // Read the file
@@ -183,7 +184,7 @@ public final class KwdFile {
         }
     }
 
-    private void readFileContents(File file) throws IOException {
+    private void readFileContents(Path file) throws IOException {
         try (IResourceReader data = new ResourceReader(file)) {
             while (data.getFilePointer() < data.length()) {
 
@@ -230,9 +231,9 @@ public final class KwdFile {
     }
 
     private void readFilePath(FilePath path) {
-        File file = null;
+        Path file = null;
         try {
-            file = new File(ConversionUtils.getRealFileName(basePath, path.getPath()));
+            file = Paths.get(ConversionUtils.getRealFileName(basePath, path.getPath()));
             readFileContents(file);
         } catch (Exception e) {
             throw new RuntimeException("Failed to read the file " + file + "!", e);

--- a/src/toniarts/openkeeper/tools/convert/map/KwdFile.java
+++ b/src/toniarts/openkeeper/tools/convert/map/KwdFile.java
@@ -34,7 +34,7 @@ import java.util.logging.Logger;
 import toniarts.openkeeper.tools.convert.ConversionUtils;
 import toniarts.openkeeper.tools.convert.IResourceChunkReader;
 import toniarts.openkeeper.tools.convert.IResourceReader;
-import toniarts.openkeeper.tools.convert.ResourceReader;
+import toniarts.openkeeper.tools.convert.FileResourceReader;
 import toniarts.openkeeper.tools.convert.map.ArtResource.ArtResourceType;
 import toniarts.openkeeper.tools.convert.map.Creature.AnimationType;
 import toniarts.openkeeper.tools.convert.map.Creature.Attraction;
@@ -173,7 +173,7 @@ public final class KwdFile {
         } else {
 
             // We need map width & height if not loaded fully, I couldn't figure out where, except the map data
-            try (IResourceReader data = new ResourceReader(ConversionUtils.getRealFileName(basePath, gameLevel.getFile(MAP)))) {
+            try (IResourceReader data = new FileResourceReader(ConversionUtils.getRealFileName(basePath, gameLevel.getFile(MAP)))) {
                 KwdHeader header = readKwdHeader(data);
                 map = new GameMap(header.getWidth(), header.getHeight());
             } catch (Exception e) {
@@ -185,7 +185,7 @@ public final class KwdFile {
     }
 
     private void readFileContents(Path file) throws IOException {
-        try (IResourceReader data = new ResourceReader(file)) {
+        try (IResourceReader data = new FileResourceReader(file)) {
             while (data.getFilePointer() < data.length()) {
 
                 // Read header (and put the file pointer to the data start)
@@ -3207,8 +3207,7 @@ public final class KwdFile {
      * Skips the file to the correct position after an item is read<br>
      * <b>Use this with the common types!</b>
      *
-     * @see toniarts.openkeeper.tools.convert.ResourceReader#checkOffset(long,
-     * long)
+     * @see toniarts.openkeeper.tools.convert.FileResourceReader#checkOffset(long, long)
      * @param header the header
      * @param reader the buffer
      * @param offset the file offset before the last item was read
@@ -3223,8 +3222,7 @@ public final class KwdFile {
      * Skips the file to the correct position after an item is read<br>
      * <b>Use this with the common types!</b>
      *
-     * @see toniarts.openkeeper.tools.convert.ResourceReader#checkOffset(long,
-     * long)
+     * @see toniarts.openkeeper.tools.convert.FileResourceReader#checkOffset(long, long)
      * @param itemSize the item size
      * @param reader the buffer
      * @param offset the file offset before the last item was read

--- a/src/toniarts/openkeeper/tools/convert/sound/BankMapFile.java
+++ b/src/toniarts/openkeeper/tools/convert/sound/BankMapFile.java
@@ -20,7 +20,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import toniarts.openkeeper.tools.convert.IResourceChunkReader;
 import toniarts.openkeeper.tools.convert.IResourceReader;
-import toniarts.openkeeper.tools.convert.ResourceReader;
+import toniarts.openkeeper.tools.convert.FileResourceReader;
 
 /**
  * Dungeon Keeper II *Bank.map files. The map files contain sound playback events of some sorts<br>
@@ -53,7 +53,7 @@ public class BankMapFile {
         this.file = file;
 
         // Read the file
-        try (IResourceReader rawMap = new ResourceReader(file)) {
+        try (IResourceReader rawMap = new FileResourceReader(file)) {
 
             // Header
             IResourceChunkReader rawMapReader = rawMap.readChunk(28);

--- a/src/toniarts/openkeeper/tools/convert/sound/BankMapFile.java
+++ b/src/toniarts/openkeeper/tools/convert/sound/BankMapFile.java
@@ -16,8 +16,8 @@
  */
 package toniarts.openkeeper.tools.convert.sound;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import toniarts.openkeeper.tools.convert.IResourceChunkReader;
 import toniarts.openkeeper.tools.convert.IResourceReader;
 import toniarts.openkeeper.tools.convert.ResourceReader;
@@ -41,7 +41,7 @@ public class BankMapFile {
     private final int unknown1; // 0 or 1 // not used
     private final long unknown2; // 0, 32769, 0xFFFFFFFF // not used
     //
-    private final File file;
+    private final Path file;
     private final BankMapFileEntry[] entries;
 
     /**
@@ -49,7 +49,7 @@ public class BankMapFile {
      *
      * @param file the *Bank.map file to read
      */
-    public BankMapFile(File file) {
+    public BankMapFile(Path file) {
         this.file = file;
 
         // Read the file
@@ -65,7 +65,7 @@ public class BankMapFile {
             };
             for (int i = 0; i < HEADER_ID.length; i++) {
                 if (check[i] != HEADER_ID[i]) {
-                    throw new RuntimeException(file.getName() + ": The file header is not valid");
+                    throw new RuntimeException(file.toString() + ": The file header is not valid");
                 }
             }
 
@@ -110,6 +110,6 @@ public class BankMapFile {
 
     @Override
     public String toString() {
-        return file.getName();
+        return file.toString();
     }
 }

--- a/src/toniarts/openkeeper/tools/convert/sound/SFFile.java
+++ b/src/toniarts/openkeeper/tools/convert/sound/SFFile.java
@@ -16,8 +16,8 @@
  */
 package toniarts.openkeeper.tools.convert.sound;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import toniarts.openkeeper.tools.convert.IResourceReader;
 import toniarts.openkeeper.tools.convert.ResourceReader;
 
@@ -29,7 +29,8 @@ public class SFFile {
 
     private final SFChunk chunk;
 
-    public SFFile(File file) {
+    public SFFile(Path file) {
+
         //Read the file
         try (IResourceReader f = new ResourceReader(file)) {
             chunk = new SFChunk(f);

--- a/src/toniarts/openkeeper/tools/convert/sound/SFFile.java
+++ b/src/toniarts/openkeeper/tools/convert/sound/SFFile.java
@@ -19,7 +19,7 @@ package toniarts.openkeeper.tools.convert.sound;
 import java.io.IOException;
 import java.nio.file.Path;
 import toniarts.openkeeper.tools.convert.IResourceReader;
-import toniarts.openkeeper.tools.convert.ResourceReader;
+import toniarts.openkeeper.tools.convert.FileResourceReader;
 
 /**
  *
@@ -32,7 +32,7 @@ public class SFFile {
     public SFFile(Path file) {
 
         //Read the file
-        try (IResourceReader f = new ResourceReader(file)) {
+        try (IResourceReader f = new FileResourceReader(file)) {
             chunk = new SFChunk(f);
         } catch (IOException e) {
             //Fug

--- a/src/toniarts/openkeeper/tools/convert/sound/SdtFile.java
+++ b/src/toniarts/openkeeper/tools/convert/sound/SdtFile.java
@@ -16,19 +16,19 @@
  */
 package toniarts.openkeeper.tools.convert.sound;
 
+import java.io.BufferedOutputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import toniarts.openkeeper.tools.convert.ConversionUtils;
 import toniarts.openkeeper.tools.convert.IResourceChunkReader;
 import toniarts.openkeeper.tools.convert.IResourceReader;
 import toniarts.openkeeper.tools.convert.ResourceReader;
-import toniarts.openkeeper.utils.PathUtils;
 
 /**
  * Stores the SDT file structure and contains the methods to handle the SDT archive<br>
@@ -136,17 +136,19 @@ public class SdtFile {
         String filename = fixFileExtension(entry);
 
         // See that the destination is formatted correctly and create it if it does not exist
-        String dest = PathUtils.fixFilePath(destination);
-        File destinationFolder = new File(dest);
-        destinationFolder.mkdirs();
-
-        dest = dest.concat(filename);
+        Path destinationFile = Paths.get(destination, filename);
+        try {
+            Files.createDirectories(destinationFile.getParent());
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to create destination folder to " + destinationFile + "!", e);
+        }
 
         // Write to the file
-        try (OutputStream outputStream = new FileOutputStream(dest)) {
-            getFileData(entry, rawSdt).writeTo(outputStream);
+        try (FileOutputStream out = new FileOutputStream(destinationFile.toFile());
+                BufferedOutputStream bout = new BufferedOutputStream(out)) {
+            getFileData(entry, rawSdt).writeTo(bout);
         } catch (IOException e) {
-            throw new RuntimeException("Failed to write to " + dest + "!", e);
+            throw new RuntimeException("Failed to write to " + destinationFile + "!", e);
         }
     }
 

--- a/src/toniarts/openkeeper/tools/convert/sound/SdtFile.java
+++ b/src/toniarts/openkeeper/tools/convert/sound/SdtFile.java
@@ -18,8 +18,8 @@ package toniarts.openkeeper.tools.convert.sound;
 
 import java.io.BufferedOutputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -144,7 +144,7 @@ public class SdtFile {
         }
 
         // Write to the file
-        try (FileOutputStream out = new FileOutputStream(destinationFile.toFile());
+        try (OutputStream out = Files.newOutputStream(destinationFile);
                 BufferedOutputStream bout = new BufferedOutputStream(out)) {
             getFileData(entry, rawSdt).writeTo(bout);
         } catch (IOException e) {

--- a/src/toniarts/openkeeper/tools/convert/sound/SdtFile.java
+++ b/src/toniarts/openkeeper/tools/convert/sound/SdtFile.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Path;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import toniarts.openkeeper.tools.convert.ConversionUtils;
@@ -41,7 +42,7 @@ public class SdtFile {
 
     private static final Pattern FILE_EXTENSION_PATTERN = Pattern.compile("([^\\s]+(\\.(?i)(mp2|wav))$)");
 
-    private final File file;
+    private final Path file;
     private final SdtFileEntry[] entries;
 
     /**
@@ -50,7 +51,7 @@ public class SdtFile {
      *
      * @param file the sdt file to read
      */
-    public SdtFile(File file) {
+    public SdtFile(Path file) {
         this.file = file;
 
         // Read the file
@@ -254,12 +255,12 @@ public class SdtFile {
         return entries;
     }
 
-    public File getFile() {
+    public Path getFile() {
         return file;
     }
 
     @Override
     public String toString() {
-        return file.getName();
+        return file.toString();
     }
 }

--- a/src/toniarts/openkeeper/tools/convert/sound/SdtFile.java
+++ b/src/toniarts/openkeeper/tools/convert/sound/SdtFile.java
@@ -28,7 +28,7 @@ import java.util.regex.Pattern;
 import toniarts.openkeeper.tools.convert.ConversionUtils;
 import toniarts.openkeeper.tools.convert.IResourceChunkReader;
 import toniarts.openkeeper.tools.convert.IResourceReader;
-import toniarts.openkeeper.tools.convert.ResourceReader;
+import toniarts.openkeeper.tools.convert.FileResourceReader;
 
 /**
  * Stores the SDT file structure and contains the methods to handle the SDT archive<br>
@@ -55,7 +55,7 @@ public class SdtFile {
         this.file = file;
 
         // Read the file
-        try (IResourceReader rawSdt = new ResourceReader(file)) {
+        try (IResourceReader rawSdt = new FileResourceReader(file)) {
 
             // Header
             IResourceChunkReader rawSdtReader = rawSdt.readChunk(4);
@@ -109,7 +109,7 @@ public class SdtFile {
     public void extractFileData(String destination) {
 
         // Open the SDT for extraction
-        try (IResourceReader rawSdt = new ResourceReader(file)) {
+        try (IResourceReader rawSdt = new FileResourceReader(file)) {
             for (SdtFileEntry entry : entries) {
                 extractFileData(entry, destination, rawSdt);
             }

--- a/src/toniarts/openkeeper/tools/convert/sound/sfx/SfxMapFile.java
+++ b/src/toniarts/openkeeper/tools/convert/sound/sfx/SfxMapFile.java
@@ -21,7 +21,7 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import toniarts.openkeeper.tools.convert.IResourceChunkReader;
 import toniarts.openkeeper.tools.convert.IResourceReader;
-import toniarts.openkeeper.tools.convert.ResourceReader;
+import toniarts.openkeeper.tools.convert.FileResourceReader;
 
 /**
  *
@@ -46,7 +46,7 @@ public class SfxMapFile {
         this.file = file;
 
         // Read the file
-        try (IResourceReader rawMap = new ResourceReader(file)) {
+        try (IResourceReader rawMap = new FileResourceReader(file)) {
 
             // Header
             IResourceChunkReader rawMapReader = rawMap.readChunk(28);

--- a/src/toniarts/openkeeper/tools/convert/sound/sfx/SfxMapFile.java
+++ b/src/toniarts/openkeeper/tools/convert/sound/sfx/SfxMapFile.java
@@ -16,8 +16,8 @@
  */
 package toniarts.openkeeper.tools.convert.sound.sfx;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Arrays;
 import toniarts.openkeeper.tools.convert.IResourceChunkReader;
 import toniarts.openkeeper.tools.convert.IResourceReader;
@@ -39,10 +39,10 @@ public class SfxMapFile {
     private final int unknown_1; // not used
     private final int unknown_2; // not used
 
-    private final File file;
+    private final Path file;
     private SfxMapFileEntry[] entries;
 
-    public SfxMapFile(File file) {
+    public SfxMapFile(Path file) {
         this.file = file;
 
         // Read the file
@@ -58,7 +58,7 @@ public class SfxMapFile {
             };
             for (int i = 0; i < HEADER_ID.length; i++) {
                 if (check[i] != HEADER_ID[i]) {
-                    throw new RuntimeException(file.getName() + ": The file header is not valid");
+                    throw new RuntimeException(file.toString() + ": The file header is not valid");
                 }
             }
 
@@ -158,7 +158,7 @@ public class SfxMapFile {
 
     @Override
     public String toString() {
-        return "SfxFile{" + "file=" + file.getName()
+        return "SfxFile{" + "file=" + file.toString()
                 + ", entries=" + Arrays.toString(entries) + "}";
     }
 }

--- a/src/toniarts/openkeeper/tools/convert/spr/SprFile.java
+++ b/src/toniarts/openkeeper/tools/convert/spr/SprFile.java
@@ -30,7 +30,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import toniarts.openkeeper.tools.convert.IResourceChunkReader;
 import toniarts.openkeeper.tools.convert.IResourceReader;
-import toniarts.openkeeper.tools.convert.ResourceReader;
+import toniarts.openkeeper.tools.convert.FileResourceReader;
 import toniarts.openkeeper.tools.convert.spr.SprEntry.SprEntryHeader;
 
 /**
@@ -57,7 +57,7 @@ public class SprFile {
     public SprFile(Path file) {
         this.sprFile = file;
 
-        try (IResourceReader data = new ResourceReader(sprFile)) {
+        try (IResourceReader data = new FileResourceReader(sprFile)) {
 
             IResourceChunkReader dataReader = data.readChunk(8);
             header = new SprHeader();

--- a/src/toniarts/openkeeper/tools/convert/spr/SprFile.java
+++ b/src/toniarts/openkeeper/tools/convert/spr/SprFile.java
@@ -17,12 +17,13 @@
 package toniarts.openkeeper.tools.convert.spr;
 
 import java.awt.Color;
-import java.io.File;
+import java.io.BufferedOutputStream;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
@@ -146,8 +147,11 @@ public class SprFile {
     public void extract(String destination, String fileName) throws FileNotFoundException, IOException {
         int i = 0;
         for (SprEntry sprite : sprites) {
-            OutputStream outputStream = new FileOutputStream(destination + File.separator + fileName + "#" + i++ + ".png");
-            sprite.buffer.writeTo(outputStream);
+            Path destinationFile = Paths.get(destination, fileName + "#" + i++ + ".png");
+            try (OutputStream out = Files.newOutputStream(destinationFile);
+                    BufferedOutputStream bout = new BufferedOutputStream(out)) {
+                sprite.buffer.writeTo(bout);
+            }
         }
     }
 }

--- a/src/toniarts/openkeeper/tools/convert/spr/SprFile.java
+++ b/src/toniarts/openkeeper/tools/convert/spr/SprFile.java
@@ -22,6 +22,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
@@ -47,12 +48,12 @@ public class SprFile {
 
     private final static String PSFB = "PSFB";
     private final SprHeader header;
-    private File sprFile;
+    private Path sprFile;
     private final List<SprEntry> sprites;
 
     private static final Logger LOGGER = Logger.getLogger(SprFile.class.getName());
 
-    public SprFile(File file) {
+    public SprFile(Path file) {
         this.sprFile = file;
 
         try (IResourceReader data = new ResourceReader(sprFile)) {
@@ -91,7 +92,7 @@ public class SprFile {
         } catch (Exception e) {
 
             //Fug
-            throw new RuntimeException("Failed to read the file " + file.getName() + "!", e);
+            throw new RuntimeException("Failed to read the file " + file.toString() + "!", e);
         }
     }
 

--- a/src/toniarts/openkeeper/tools/convert/str/MbToUniFile.java
+++ b/src/toniarts/openkeeper/tools/convert/str/MbToUniFile.java
@@ -16,9 +16,9 @@
  */
 package toniarts.openkeeper.tools.convert.str;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.CharBuffer;
+import java.nio.file.Path;
 import toniarts.openkeeper.tools.convert.IResourceChunkReader;
 import toniarts.openkeeper.tools.convert.IResourceReader;
 import toniarts.openkeeper.tools.convert.ResourceReader;
@@ -47,7 +47,7 @@ public class MbToUniFile {
     private final int threshold;
     private final int count;
 
-    public MbToUniFile(File file) {
+    public MbToUniFile(Path file) {
         try (IResourceReader rawCodepage = new ResourceReader(file)) {
 
             // Check the header

--- a/src/toniarts/openkeeper/tools/convert/str/MbToUniFile.java
+++ b/src/toniarts/openkeeper/tools/convert/str/MbToUniFile.java
@@ -21,7 +21,7 @@ import java.nio.CharBuffer;
 import java.nio.file.Path;
 import toniarts.openkeeper.tools.convert.IResourceChunkReader;
 import toniarts.openkeeper.tools.convert.IResourceReader;
-import toniarts.openkeeper.tools.convert.ResourceReader;
+import toniarts.openkeeper.tools.convert.FileResourceReader;
 
 /**
  * Dungeon Keeper 2 MultiByte to Unicode codepage file reader. The file is used
@@ -48,7 +48,7 @@ public class MbToUniFile {
     private final int count;
 
     public MbToUniFile(Path file) {
-        try (IResourceReader rawCodepage = new ResourceReader(file)) {
+        try (IResourceReader rawCodepage = new FileResourceReader(file)) {
 
             // Check the header
             IResourceChunkReader rawCodepageReader = rawCodepage.readChunk(8);

--- a/src/toniarts/openkeeper/tools/convert/str/StrFile.java
+++ b/src/toniarts/openkeeper/tools/convert/str/StrFile.java
@@ -30,7 +30,7 @@ import java.util.logging.Logger;
 import toniarts.openkeeper.tools.convert.ConversionUtils;
 import toniarts.openkeeper.tools.convert.IResourceChunkReader;
 import toniarts.openkeeper.tools.convert.IResourceReader;
-import toniarts.openkeeper.tools.convert.ResourceReader;
+import toniarts.openkeeper.tools.convert.FileResourceReader;
 
 /**
  * Reads the Dungeon Keeper 2 STR files<br>
@@ -76,7 +76,7 @@ public class StrFile {
         this.codePage = codePage;
 
         // Read the file
-        try (IResourceReader rawStr = new ResourceReader(file)) {
+        try (IResourceReader rawStr = new FileResourceReader(file)) {
 
             // Check the header
             IResourceChunkReader rawStrReader = rawStr.readChunk(12);

--- a/src/toniarts/openkeeper/tools/convert/str/StrFile.java
+++ b/src/toniarts/openkeeper/tools/convert/str/StrFile.java
@@ -16,9 +16,9 @@
  */
 package toniarts.openkeeper.tools.convert.str;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -60,7 +60,7 @@ public class StrFile {
      *
      * @param file the str file to read
      */
-    public StrFile(File file) {
+    public StrFile(Path file) {
         this(readCodePage(file), file);
     }
 
@@ -72,7 +72,7 @@ public class StrFile {
      * @param codePage the code page
      * @param file the str file to read
      */
-    public StrFile(MbToUniFile codePage, File file) {
+    public StrFile(MbToUniFile codePage, Path file) {
         this.codePage = codePage;
 
         // Read the file
@@ -137,17 +137,17 @@ public class StrFile {
      * @return code page as char buffer
      * @throws RuntimeException may fail miserably
      */
-    private static MbToUniFile readCodePage(File file) throws RuntimeException {
+    private static MbToUniFile readCodePage(Path file) throws RuntimeException {
 
         // We also need the codepage, assume it is in the same directory
-        return new MbToUniFile(new File(file.getParent().concat(File.separator).concat("MBToUni.dat")));
+        return new MbToUniFile(file.getParent().resolve("MBToUni.dat"));
     }
 
     /**
      * Decodes one entry in STR file
      *
      * @param data the entry bytes
-     * @return returns null if error occured, otherwise the decoded string
+     * @return returns null if error occurred, otherwise the decoded string
      */
     private String decodeEntry(final IResourceChunkReader data) {
         ByteBuffer byteBuffer = data.getByteBuffer();

--- a/src/toniarts/openkeeper/tools/convert/textures/enginetextures/EngineTexturesFile.java
+++ b/src/toniarts/openkeeper/tools/convert/textures/enginetextures/EngineTexturesFile.java
@@ -21,8 +21,8 @@ import java.awt.Graphics;
 import java.awt.image.BufferedImage;
 import java.io.BufferedOutputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -199,7 +199,7 @@ public class EngineTexturesFile implements Iterable<String> {
         }
 
         // Write to the file
-        try (FileOutputStream out = new FileOutputStream(destinationFile.toFile());
+        try (OutputStream out = Files.newOutputStream(destinationFile);
                 BufferedOutputStream bout = new BufferedOutputStream(out)) {
             getFileData(textureEntry, rawTextures).writeTo(bout);
         } catch (IOException e) {

--- a/src/toniarts/openkeeper/tools/convert/textures/enginetextures/EngineTexturesFile.java
+++ b/src/toniarts/openkeeper/tools/convert/textures/enginetextures/EngineTexturesFile.java
@@ -35,7 +35,7 @@ import javax.imageio.ImageIO;
 import toniarts.openkeeper.tools.convert.ConversionUtils;
 import toniarts.openkeeper.tools.convert.IResourceChunkReader;
 import toniarts.openkeeper.tools.convert.IResourceReader;
-import toniarts.openkeeper.tools.convert.ResourceReader;
+import toniarts.openkeeper.tools.convert.FileResourceReader;
 
 /**
  * Reads Dungeon Keeper II EngineTextures.dat file to a structure<br>
@@ -64,7 +64,7 @@ public class EngineTexturesFile implements Iterable<String> {
 
         // Read the names from the DIR file in the same folder
         Path dirFile = Paths.get(file.toString().substring(0, file.toString().length() - 3) + "dir");
-        try (IResourceReader rawDir = new ResourceReader(dirFile)) {
+        try (IResourceReader rawDir = new FileResourceReader(dirFile)) {
 
             // File format:
             // HEADER:
@@ -88,7 +88,7 @@ public class EngineTexturesFile implements Iterable<String> {
             engineTextureEntries = new HashMap<>(numberOfEntries);
 
             dirReader = rawDir.readChunk(size);
-            try (IResourceReader rawTextures = new ResourceReader(file)) {
+            try (IResourceReader rawTextures = new FileResourceReader(file)) {
                 do {
                     String name = ConversionUtils.convertFileSeparators(dirReader.readVaryingLengthStrings(1).get(0));
                     int offset = dirReader.readUnsignedInteger();
@@ -139,7 +139,7 @@ public class EngineTexturesFile implements Iterable<String> {
     public void extractFileData(String destination) {
 
         // Open the Texture file for extraction
-        try (IResourceReader rawTextures = new ResourceReader(file)) {
+        try (IResourceReader rawTextures = new FileResourceReader(file)) {
 
             for (String textureEntry : engineTextureEntries.keySet()) {
                 extractFileData(textureEntry, destination, rawTextures, true);
@@ -162,7 +162,7 @@ public class EngineTexturesFile implements Iterable<String> {
     public Path extractFileData(String textureEntry, String destination, boolean overwrite) {
 
         // Open the Texture file for extraction
-        try (IResourceReader rawTextures = new ResourceReader(file)) {
+        try (IResourceReader rawTextures = new FileResourceReader(file)) {
             return extractFileData(textureEntry, destination, rawTextures, overwrite);
         } catch (IOException e) {
 

--- a/src/toniarts/openkeeper/tools/convert/textures/enginetextures/EngineTexturesFile.java
+++ b/src/toniarts/openkeeper/tools/convert/textures/enginetextures/EngineTexturesFile.java
@@ -25,6 +25,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -59,11 +60,11 @@ public class EngineTexturesFile implements Iterable<String> {
 
     private static final Logger LOGGER = Logger.getLogger(EngineTexturesFile.class.getName());
 
-    public EngineTexturesFile(File file) {
-        this.file = file.toPath();
+    public EngineTexturesFile(Path file) {
+        this.file = file;
 
         // Read the names from the DIR file in the same folder
-        File dirFile = new File(file.toString().substring(0, file.toString().length() - 3).concat("dir"));
+        Path dirFile = Paths.get(file.toString().substring(0, file.toString().length() - 3) + "dir");
         try (IResourceReader rawDir = new ResourceReader(dirFile)) {
 
             // File format:

--- a/src/toniarts/openkeeper/tools/convert/textures/loadingscreens/LoadingScreenFile.java
+++ b/src/toniarts/openkeeper/tools/convert/textures/loadingscreens/LoadingScreenFile.java
@@ -17,7 +17,6 @@
 package toniarts.openkeeper.tools.convert.textures.loadingscreens;
 
 import java.awt.image.BufferedImage;
-import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import toniarts.openkeeper.tools.convert.ConversionUtils;
@@ -34,9 +33,9 @@ public class LoadingScreenFile {
 
     private final BufferedImage image;
 
-    public LoadingScreenFile(ByteArrayOutputStream fileData) {
+    public LoadingScreenFile(byte[] fileData) {
 
-        ByteBuffer buf = ByteBuffer.wrap(fileData.toByteArray());
+        ByteBuffer buf = ByteBuffer.wrap(fileData);
         buf.order(ByteOrder.LITTLE_ENDIAN);
 
         //Read the header

--- a/src/toniarts/openkeeper/tools/convert/wad/WadFile.java
+++ b/src/toniarts/openkeeper/tools/convert/wad/WadFile.java
@@ -32,9 +32,9 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import toniarts.openkeeper.tools.convert.ConversionUtils;
+import toniarts.openkeeper.tools.convert.FileResourceReader;
 import toniarts.openkeeper.tools.convert.IResourceChunkReader;
 import toniarts.openkeeper.tools.convert.IResourceReader;
-import toniarts.openkeeper.tools.convert.ResourceReader;
 
 /**
  * Stores the wad file structure and contains the methods to handle the WAD archive<br>
@@ -64,7 +64,7 @@ public class WadFile {
         this.file = file;
 
         // Read the file
-        try (IResourceReader rawWad = new ResourceReader(file)) {
+        try (IResourceReader rawWad = new FileResourceReader(file)) {
 
             // Check the header
             IResourceChunkReader reader = rawWad.readChunk(8);
@@ -163,7 +163,7 @@ public class WadFile {
     public void extractFileData(String destination) {
 
         // Open the WAD for extraction
-        try (IResourceReader rawWad = new ResourceReader(file)) {
+        try (IResourceReader rawWad = new FileResourceReader(file)) {
 
             for (String fileName : wadFileEntries.keySet()) {
                 extractFileData(fileName, destination, rawWad);
@@ -214,7 +214,7 @@ public class WadFile {
     public Path extractFileData(String fileName, String destination) {
 
         // Open the WAD for extraction
-        try (IResourceReader rawWad = new ResourceReader(file)) {
+        try (IResourceReader rawWad = new FileResourceReader(file)) {
             return extractFileData(fileName, destination, rawWad);
         } catch (Exception e) {
 
@@ -269,11 +269,11 @@ public class WadFile {
      * @param fileName the file to extract
      * @return the file data
      */
-    public ByteArrayOutputStream getFileData(String fileName) {
+    public byte[] getFileData(String fileName) {
 
         // Open the WAD for extraction
-        try (IResourceReader rawWad = new ResourceReader(file)) {
-            return getFileData(fileName, rawWad);
+        try (IResourceReader rawWad = new FileResourceReader(file)) {
+            return getFileData(fileName, rawWad).toByteArray();
         } catch (Exception e) {
 
             // Fug

--- a/src/toniarts/openkeeper/tools/convert/wad/WadFile.java
+++ b/src/toniarts/openkeeper/tools/convert/wad/WadFile.java
@@ -19,8 +19,8 @@ package toniarts.openkeeper.tools.convert.wad;
 import java.io.BufferedOutputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -194,7 +194,7 @@ public class WadFile {
         }
 
         // Write to the file
-        try (FileOutputStream out = new FileOutputStream(destinationFile.toFile());
+        try (OutputStream out = Files.newOutputStream(destinationFile);
                 BufferedOutputStream bout = new BufferedOutputStream(out)) {
             getFileData(fileName, rawWad).writeTo(bout);
         } catch (IOException e) {

--- a/src/toniarts/openkeeper/tools/convert/wad/WadFile.java
+++ b/src/toniarts/openkeeper/tools/convert/wad/WadFile.java
@@ -22,6 +22,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
@@ -59,8 +60,8 @@ public class WadFile {
      *
      * @param file the wad file to read
      */
-    public WadFile(File file) {
-        this.file = file.toPath();
+    public WadFile(Path file) {
+        this.file = file;
 
         // Read the file
         try (IResourceReader rawWad = new ResourceReader(file)) {
@@ -181,7 +182,7 @@ public class WadFile {
      * @param destination destination directory
      * @param rawWad the opened WAD file
      */
-    private File extractFileData(String fileName, String destination, IResourceReader rawWad) {
+    private Path extractFileData(String fileName, String destination, IResourceReader rawWad) {
 
         // See that the destination is formatted correctly and create it if it does not exist
         String dest = PathUtils.fixFilePath(destination);
@@ -198,10 +199,11 @@ public class WadFile {
         // Write to the file
         try (OutputStream outputStream = new FileOutputStream(dest)) {
             getFileData(fileName, rawWad).writeTo(outputStream);
-            return new File(dest);
         } catch (IOException e) {
             throw new RuntimeException("Failed to write to " + dest + "!", e);
         }
+
+        return Paths.get(dest);
     }
 
     /**
@@ -211,7 +213,7 @@ public class WadFile {
      * @param destination destination directory
      * @return the file for the extracted contents
      */
-    public File extractFileData(String fileName, String destination) {
+    public Path extractFileData(String fileName, String destination) {
 
         // Open the WAD for extraction
         try (IResourceReader rawWad = new ResourceReader(file)) {

--- a/src/toniarts/openkeeper/tools/modelviewer/ModelViewer.java
+++ b/src/toniarts/openkeeper/tools/modelviewer/ModelViewer.java
@@ -168,8 +168,8 @@ public class ModelViewer extends SimpleApplication {
 
     public static void main(String[] args) {
 
-        //Take Dungeon Keeper 2 root folder as parameter
-        if (args.length != 1 || !new File(args[0]).exists()) {
+        // Take Dungeon Keeper 2 root folder as parameter
+        if (args.length != 1 || !Files.exists(Paths.get(args[0]))) {
             dkIIFolder = PathUtils.getDKIIFolder();
             if (dkIIFolder == null) {
                 throw new RuntimeException("Please provide Dungeon Keeper II main folder as a first parameter!");

--- a/src/toniarts/openkeeper/tools/modelviewer/ModelViewer.java
+++ b/src/toniarts/openkeeper/tools/modelviewer/ModelViewer.java
@@ -48,7 +48,9 @@ import de.lessvoid.nifty.Nifty;
 import de.lessvoid.nifty.controls.DropDown;
 import de.lessvoid.nifty.controls.ListBox;
 import java.io.File;
-import java.io.FilenameFilter;
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -59,6 +61,7 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import toniarts.openkeeper.audio.plugins.MP2Loader;
+import toniarts.openkeeper.game.MapSelector;
 import toniarts.openkeeper.game.data.ISoundable;
 import toniarts.openkeeper.game.sound.SoundCategory;
 import toniarts.openkeeper.game.sound.SoundFile;
@@ -568,32 +571,25 @@ public class ModelViewer extends SimpleApplication {
      * Fill the listbox with items
      *
      * @param object list of objects (cached)
-     * @param rootDirectory the root directory (i.e. DK II dir or the dev dir),
-     * must be relative to the actual directory of where the objects are
-     * gathered
      * @param directory the actual directory where the objects are get
      * @param extension the file extension of the objects wanted
      */
-    private void fillWithFiles(List<String> object, final String rootDirectory,
+    private void fillWithFiles(List<String> object,
             final String directory, final String extension) {
 
         ListBox<String> listBox = screen.getItemsControl();
 
         if (object == null) {
 
-            //Find all the models
+            // Find all the files
             object = new ArrayList<>();
-            File f = new File(directory);
-            File[] files = f.listFiles(new FilenameFilter() {
-                @Override
-                public boolean accept(File dir, String name) {
-                    return name.toLowerCase().endsWith(".".concat(extension));
+            try (DirectoryStream<Path> stream = Files.newDirectoryStream(Paths.get(directory), PathUtils.getFilterForFilesEndingWith(extension))) {
+                for (Path file : stream) {
+                    String key = file.getFileName().toString();
+                    object.add(key.substring(0, key.length() - 4));
                 }
-            });
-            Path path = new File(rootDirectory).toPath();
-            for (File file : files) {
-                String key = file.getName();
-                object.add(key.substring(0, key.length() - 4));
+            } catch (IOException ex) {
+                Logger.getLogger(MapSelector.class.getName()).log(Level.SEVERE, "Failed to load the maps!", ex);
             }
         }
 
@@ -627,12 +623,12 @@ public class ModelViewer extends SimpleApplication {
         screen.getItemsControl().clear();
         switch (type) {
             case MODELS: {
-                fillWithFiles(models, AssetsConverter.getAssetsFolder(), AssetsConverter.getAssetsFolder()
-                        + AssetsConverter.MODELS_FOLDER + File.separator, "j3o");
+                fillWithFiles(models, AssetsConverter.getAssetsFolder()
+                        + AssetsConverter.MODELS_FOLDER + File.separator, ".j3o");
                 break;
             }
             case MAPS: {
-                fillWithFiles(maps, dkIIFolder, dkIIFolder + PathUtils.DKII_MAPS_FOLDER, "kwd");
+                fillWithFiles(maps, dkIIFolder + PathUtils.DKII_MAPS_FOLDER, ".kwd");
                 break;
             }
             case CREATURES: {

--- a/src/toniarts/openkeeper/tools/modelviewer/ModelViewer.java
+++ b/src/toniarts/openkeeper/tools/modelviewer/ModelViewer.java
@@ -50,6 +50,7 @@ import de.lessvoid.nifty.controls.ListBox;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -121,7 +122,7 @@ public class ModelViewer extends SimpleApplication {
     private DirectionalLight dl;
     private NiftyJmeDisplay niftyDisplay;
     private ModelViewerScreenController screen;
-    private File kmfModel = null;
+    private Path kmfModel = null;
     private boolean wireframe = false;
     private boolean rotate = true;
     private boolean showNormals = false;
@@ -178,7 +179,7 @@ public class ModelViewer extends SimpleApplication {
         app.start();
     }
 
-    public ModelViewer(File kmfModel, String dkFolder) {
+    public ModelViewer(Path kmfModel, String dkFolder) {
         this();
         this.kmfModel = kmfModel;
         dkIIFolder = dkFolder;
@@ -407,7 +408,7 @@ public class ModelViewer extends SimpleApplication {
             case MAPS: {
                 // Load the selected map
                 String file = (String) selection + ".kwd";
-                KwdFile kwd = new KwdFile(dkIIFolder, new File(dkIIFolder + PathUtils.DKII_MAPS_FOLDER + file));
+                KwdFile kwd = new KwdFile(dkIIFolder, Paths.get(dkIIFolder, PathUtils.DKII_MAPS_FOLDER, file));
                 Node spat = (Node) new MapLoader(this.getAssetManager(), kwd,
                         new EffectManagerState(kwd, this.getAssetManager()), null,
                         new ObjectLoader(kwd, null)) {
@@ -690,7 +691,7 @@ public class ModelViewer extends SimpleApplication {
 
             // Read Alcatraz.kwd by default
             kwdFile = new KwdFile(dkIIFolder,
-                    new File(dkIIFolder + PathUtils.DKII_MAPS_FOLDER + "Alcatraz.kwd"));
+                    Paths.get(dkIIFolder, PathUtils.DKII_MAPS_FOLDER, "Alcatraz.kwd"));
         }
 
         return kwdFile;

--- a/src/toniarts/openkeeper/utils/PathUtils.java
+++ b/src/toniarts/openkeeper/utils/PathUtils.java
@@ -20,7 +20,9 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import toniarts.openkeeper.tools.convert.ConversionUtils;
 
@@ -116,6 +118,23 @@ public class PathUtils {
             os.write(buffer, 0, len);
         }
         return os.toByteArray();
+    }
+
+    /**
+     * Creates a filter for getting files that end in the wanted suffix. This is
+     * case insensitive comparison.
+     *
+     * @param suffix the file suffix to search for
+     * @return filter to use when going through file system
+     */
+    public static DirectoryStream.Filter<Path> getFilterForFilesEndingWith(String suffix) {
+        return new DirectoryStream.Filter<Path>() {
+
+            @Override
+            public boolean accept(Path entry) throws IOException {
+                return entry.getFileName().toString().toLowerCase().endsWith(suffix) && !Files.isDirectory(entry);
+            }
+        };
     }
 
 }

--- a/src/toniarts/openkeeper/utils/PathUtils.java
+++ b/src/toniarts/openkeeper/utils/PathUtils.java
@@ -16,10 +16,8 @@
  */
 package toniarts.openkeeper.utils;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -101,23 +99,6 @@ public class PathUtils {
             return fixFilePath(ConversionUtils.getCanonicalRelativePath(rootFolder, folder));
         }
         return fixFilePath(folder);
-    }
-
-    /**
-     * Read input stream to bytes. Can be removed in Java 9 as the InputStream
-     * provides this functionality then
-     *
-     * @param is the input stream to read
-     * @return byte array read from the input stream
-     * @throws IOException may fail
-     */
-    public static byte[] getBytesFromInputStream(InputStream is) throws IOException {
-        ByteArrayOutputStream os = new ByteArrayOutputStream();
-        byte[] buffer = new byte[0xFFFF];
-        for (int len = is.read(buffer); len != -1; len = is.read(buffer)) {
-            os.write(buffer, 0, len);
-        }
-        return os.toByteArray();
     }
 
     /**

--- a/src/toniarts/openkeeper/utils/SettingUtils.java
+++ b/src/toniarts/openkeeper/utils/SettingUtils.java
@@ -17,15 +17,16 @@
 package toniarts.openkeeper.utils;
 
 import com.jme3.system.AppSettings;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import toniarts.openkeeper.Main;
 
 public class SettingUtils {
 
@@ -54,21 +55,23 @@ public class SettingUtils {
     private void loadSettings() {
 
         // Init the application settings which contain just the conversion & folder data
-        File settingsFile = new File(SETTINGS_FILE);
-        if (settingsFile.exists()) {
-            try (InputStream is = new FileInputStream(settingsFile)) {
-                settings.load(is);
+        Path settingsFile = Paths.get(SETTINGS_FILE);
+        if (Files.exists(settingsFile)) {
+            try (InputStream in = Files.newInputStream(settingsFile);
+                    BufferedInputStream bin = new BufferedInputStream(in)) {
+                settings.load(bin);
             } catch (IOException ex) {
-                LOGGER.log(java.util.logging.Level.WARNING, "Settings file failed to load from " + settingsFile + "!", ex);
+                LOGGER.log(Level.WARNING, "Settings file failed to load from " + settingsFile + "!", ex);
             }
         }
     }
 
     public void saveSettings() {
-        try (OutputStream os = new FileOutputStream(new File(SETTINGS_FILE))) {
-            settings.save(os);
+        try (OutputStream out = Files.newOutputStream(Paths.get(SETTINGS_FILE));
+                BufferedOutputStream bout = new BufferedOutputStream(out)) {
+            settings.save(bout);
         } catch (IOException ex) {
-            Logger.getLogger(Main.class.getName()).log(Level.WARNING, "Settings file failed to save!", ex);
+            LOGGER.log(Level.WARNING, "Settings file failed to save!", ex);
         }
     }
 }

--- a/src/toniarts/openkeeper/utils/SettingUtils.java
+++ b/src/toniarts/openkeeper/utils/SettingUtils.java
@@ -31,7 +31,7 @@ import java.util.logging.Logger;
 public class SettingUtils {
 
     private static final Logger LOGGER = Logger.getLogger(SettingUtils.class.getName());
-    private final static String SETTINGS_FILE = "openkeeper.properties";
+    private final static Path SETTINGS_FILE = Paths.get("openkeeper.properties");
     private final AppSettings settings;
     private final static SettingUtils instance;
 
@@ -55,19 +55,18 @@ public class SettingUtils {
     private void loadSettings() {
 
         // Init the application settings which contain just the conversion & folder data
-        Path settingsFile = Paths.get(SETTINGS_FILE);
-        if (Files.exists(settingsFile)) {
-            try (InputStream in = Files.newInputStream(settingsFile);
+        if (Files.exists(SETTINGS_FILE)) {
+            try (InputStream in = Files.newInputStream(SETTINGS_FILE);
                     BufferedInputStream bin = new BufferedInputStream(in)) {
                 settings.load(bin);
             } catch (IOException ex) {
-                LOGGER.log(Level.WARNING, "Settings file failed to load from " + settingsFile + "!", ex);
+                LOGGER.log(Level.WARNING, "Settings file failed to load from " + SETTINGS_FILE + "!", ex);
             }
         }
     }
 
     public void saveSettings() {
-        try (OutputStream out = Files.newOutputStream(Paths.get(SETTINGS_FILE));
+        try (OutputStream out = Files.newOutputStream(SETTINGS_FILE);
                 BufferedOutputStream bout = new BufferedOutputStream(out)) {
             settings.save(bout);
         } catch (IOException ex) {

--- a/src/toniarts/openkeeper/video/MovieState.java
+++ b/src/toniarts/openkeeper/video/MovieState.java
@@ -30,7 +30,6 @@ import com.jme3.input.controls.TouchTrigger;
 import com.jme3.math.ColorRGBA;
 import com.jme3.scene.Geometry;
 import com.jme3.scene.shape.Quad;
-import java.io.File;
 import java.io.FileNotFoundException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -80,7 +79,7 @@ public abstract class MovieState extends AbstractAppState {
         this.app.getGuiNode().attachChild(movieScreen);
 
         // Create the player
-        player = new TgqPlayer(new File(movie)) {
+        player = new TgqPlayer(Paths.get(movie)) {
             @Override
             protected void onPlayingEnd() {
                 app.getStateManager().detach(MovieState.this);

--- a/src/toniarts/openkeeper/video/TgqPlayer.java
+++ b/src/toniarts/openkeeper/video/TgqPlayer.java
@@ -16,8 +16,8 @@
  */
 package toniarts.openkeeper.video;
 
-import java.io.File;
 import java.nio.ByteBuffer;
+import java.nio.file.Path;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.logging.Level;
@@ -33,7 +33,7 @@ import toniarts.openkeeper.video.tgq.TgqFile;
 import toniarts.openkeeper.video.tgq.TgqFrame;
 
 /**
- * "Mediaplayer" for TGQ files<br>
+ * "Media player" for TGQ files<br>
  * Kinda like an interface between the actual canvas and the decoder<br>
  * Not rewindable etc.<br>
  * Very simplistic, the buffer is just filled up once. If the decoder is too
@@ -45,7 +45,7 @@ import toniarts.openkeeper.video.tgq.TgqFrame;
  */
 public abstract class TgqPlayer {
 
-    private final File file;
+    private final Path file;
     private static final int FPS = 25; // The specs say 15 FPS, but with this they are totally in sync, dunno why
     private static final int FRAME_INTERVAL = (int) Math.floor(1000 / FPS); // In milliseconds
     private static final float FRAME_BUFFER_SIZE = 3; // In seconds, there is no fancy counter etc.
@@ -64,7 +64,7 @@ public abstract class TgqPlayer {
     private boolean stopped = true;
     private static final Logger logger = Logger.getLogger(TgqPlayer.class.getName());
 
-    public TgqPlayer(File file) {
+    public TgqPlayer(Path file) {
         this.file = file;
     }
 
@@ -352,9 +352,9 @@ public abstract class TgqPlayer {
      */
     private class TgqDecoder implements Runnable {
 
-        private final File file;
+        private final Path file;
 
-        private TgqDecoder(File file) {
+        private TgqDecoder(Path file) {
             this.file = file;
         }
 

--- a/src/toniarts/openkeeper/video/tgq/TgqFile.java
+++ b/src/toniarts/openkeeper/video/tgq/TgqFile.java
@@ -18,6 +18,8 @@ package toniarts.openkeeper.video.tgq;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.imageio.ImageIO;
@@ -72,7 +74,7 @@ public abstract class TgqFile implements AutoCloseable {
         new File(args[1]).mkdirs();
 
         // Create the video parser
-        try (TgqFile tgq = new TgqFile(new File(args[0])) {
+        try (TgqFile tgq = new TgqFile(Paths.get(args[0])) {
             @Override
             protected void addVideoFrame(TgqFrame frame) {
                 File outputfile = new File(args[1].concat("Frame").concat(frame.getFrameIndex() + "").concat(".png"));
@@ -101,7 +103,7 @@ public abstract class TgqFile implements AutoCloseable {
         }
     }
 
-    public TgqFile(File file) throws IOException {
+    public TgqFile(Path file) throws IOException {
         this.file = new ResourceReader(file);
     }
 

--- a/src/toniarts/openkeeper/video/tgq/TgqFile.java
+++ b/src/toniarts/openkeeper/video/tgq/TgqFile.java
@@ -26,7 +26,7 @@ import java.util.logging.Logger;
 import javax.imageio.ImageIO;
 import toniarts.openkeeper.tools.convert.IResourceChunkReader;
 import toniarts.openkeeper.tools.convert.IResourceReader;
-import toniarts.openkeeper.tools.convert.ResourceReader;
+import toniarts.openkeeper.tools.convert.FileResourceReader;
 
 /**
  * Parses a DK II movie file<br>
@@ -106,7 +106,7 @@ public abstract class TgqFile implements AutoCloseable {
     }
 
     public TgqFile(Path file) throws IOException {
-        this.file = new ResourceReader(file);
+        this.file = new FileResourceReader(file);
     }
 
     @Override

--- a/src/toniarts/openkeeper/video/tgq/TgqFile.java
+++ b/src/toniarts/openkeeper/video/tgq/TgqFile.java
@@ -18,6 +18,7 @@ package toniarts.openkeeper.video.tgq;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.logging.Level;
@@ -67,14 +68,15 @@ public abstract class TgqFile implements AutoCloseable {
         }
 
         // Take a movie file as parameter
-        if (!new File(args[0]).exists()) {
+        Path file = Paths.get(args[1]);
+        if (!Files.exists(file)) {
             throw new RuntimeException("Movie file doesn't exist!");
         }
 
-        new File(args[1]).mkdirs();
+        Files.createDirectories(file);
 
         // Create the video parser
-        try (TgqFile tgq = new TgqFile(Paths.get(args[0])) {
+        try (TgqFile tgq = new TgqFile(file) {
             @Override
             protected void addVideoFrame(TgqFrame frame) {
                 File outputfile = new File(args[1].concat("Frame").concat(frame.getFrameIndex() + "").concat(".png"));


### PR DESCRIPTION
io -> nio where available. Mostly it is just an API change, maybe marginal speedups just by that. The major functional changes however have a huge impact especially on the initial asset conversion. We now read / write files through buffers that provide much more optimal performance. Asset conversion also did a lot of temp files when processing files in WAD archives, now all this is performed in-memory without the need for any temp files.

The initial asset conversion for me is now roughly just 30s with this. So further 2 mins shaved (compared to just the multithreading stuff, the earlier NIO stuff already sped this up a lot). Definitely better than the 10 minutes that we started with.