### PR TITLE
Font compatibility

### DIFF
--- a/src/toniarts/openkeeper/tools/convert/AssetsConverter.java
+++ b/src/toniarts/openkeeper/tools/convert/AssetsConverter.java
@@ -66,7 +66,7 @@ public abstract class AssetsConverter implements IConversionTaskUpdate {
         INTERFACE_TEXTS(3, new ConvertProcess[]{}),
         PATHS(4, new ConvertProcess[]{}),
         HI_SCORES(2, new ConvertProcess[]{}),
-        FONTS(3, new ConvertProcess[]{}),
+        FONTS(4, new ConvertProcess[]{}),
         MAP_THUMBNAILS(3, new ConvertProcess[]{TEXTURES});
 
         private ConvertProcess(int version, ConvertProcess[] dependencies) {

--- a/src/toniarts/openkeeper/tools/convert/FontCreator.java
+++ b/src/toniarts/openkeeper/tools/convert/FontCreator.java
@@ -33,13 +33,13 @@ import toniarts.openkeeper.tools.convert.bf4.Bf4File;
  *
  * @author Toni Helenius <helenius.toni@gmail.com>
  */
-public abstract class FontCreator {
+public class FontCreator {
 
     private final String description;
     private final BufferedImage fontImage;
     private final Set<Integer> insertedChars;
 
-    public FontCreator(Bf4File fontFile) {
+    public FontCreator(Bf4File fontFile, int fontSize, String fileName) {
 
         // Create right sized font image
         fontImage = getFontImage(fontFile);
@@ -47,10 +47,10 @@ public abstract class FontCreator {
         // Write the header description
         StringBuilder sb = new StringBuilder(1000);
         sb.append("info face=\"");
-        sb.append(getFileName().substring(0, getFileName().length() - 4)); // For current Nifty batching the face needs to be unique
+        sb.append(fileName.substring(0, fileName.length() - 4)); // For current Nifty batching the face needs to be unique
         sb.append("\" ");
         sb.append("size=");
-        sb.append(getFontSize());
+        sb.append(fontSize);
         sb.append(" ");
         sb.append("bold=0 ");
         sb.append("italic=0 ");
@@ -75,7 +75,7 @@ public abstract class FontCreator {
         sb.append("packed=0 ");
         sb.append("\n");
         sb.append("page id=0 file=\"");
-        sb.append(getFileName());
+        sb.append(fileName);
         sb.append("\"\n");
         sb.append("chars count=");
         sb.append(fontFile.getMaxCodePoint());
@@ -164,18 +164,4 @@ public abstract class FontCreator {
     public BufferedImage getFontImage() {
         return fontImage;
     }
-
-    /**
-     * The font size in points
-     *
-     * @return font size
-     */
-    protected abstract int getFontSize();
-
-    /**
-     * The image file name where the fonts are
-     *
-     * @return font image file name
-     */
-    protected abstract String getFileName();
 }

--- a/src/toniarts/openkeeper/tools/convert/FontCreator.java
+++ b/src/toniarts/openkeeper/tools/convert/FontCreator.java
@@ -37,6 +37,8 @@ import toniarts.openkeeper.tools.convert.bf4.Bf4File;
  */
 public class FontCreator {
 
+    private static final int MAX_SIZE = 2048;
+
     private final String description;
     private final List<FontImage> fontImages;
 
@@ -220,14 +222,13 @@ public class FontCreator {
      */
     private static int getFontImageSize(Bf4File fontFile) {
 
-        // Try to create a nice square (power of two is really waste of space...)
+        // Calculate the totals
         int area = fontFile.getMaxHeight() * fontFile.getAvgWidth() * fontFile.getGlyphCount(); // This is how many square pixels we need, approximate
-        int side = (int) FastMath.ceil(FastMath.sqrt(area)) + 10; // The plus is just a bit padding to make sure everything fits
+        int side = (int) FastMath.ceil(FastMath.sqrt(area));
 
-        // Divisible by two
-        if (side % 2 != 0) {
-            side++;
-        }
+        // The next power of two
+        side = Integer.highestOneBit(side - 1) * 2;
+        side = Math.min(MAX_SIZE, side);
 
         return side;
     }

--- a/src/toniarts/openkeeper/tools/convert/IResourceReader.java
+++ b/src/toniarts/openkeeper/tools/convert/IResourceReader.java
@@ -30,7 +30,7 @@ public interface IResourceReader extends Closeable {
     /**
      * End of file
      *
-     * @return true if filepointer >= length of file
+     * @return true if file pointer >= length of file
      * @throws IOException
      */
     boolean isEof() throws IOException;

--- a/src/toniarts/openkeeper/tools/convert/bf4/Bf4File.java
+++ b/src/toniarts/openkeeper/tools/convert/bf4/Bf4File.java
@@ -159,7 +159,7 @@ public class Bf4File implements Iterable<Bf4Entry> {
      * transparent. 4-bits per pixel.
      *
      * @param entry the font entry
-     * @param bytes tha data payload
+     * @param bytes the data payload
      * @return image
      */
     private BufferedImage decodeFontImage(final Bf4Entry entry, final byte[] bytes) throws IOException {

--- a/src/toniarts/openkeeper/tools/convert/bf4/Bf4File.java
+++ b/src/toniarts/openkeeper/tools/convert/bf4/Bf4File.java
@@ -56,6 +56,7 @@ public class Bf4File implements Iterable<Bf4Entry> {
     private int maxCodePoint = 0;
     private int glyphCount = 0;
     private int avgWidth = 0;
+    private int totalWidth = 0;
 
     static {
 
@@ -104,6 +105,7 @@ public class Bf4File implements Iterable<Bf4Entry> {
 
             // Sort them
             Collections.sort(entries);
+            totalWidth = avgWidth;
             avgWidth = (int) Math.ceil((float) avgWidth / getGlyphCount());
         } catch (IOException e) {
 
@@ -275,6 +277,15 @@ public class Bf4File implements Iterable<Bf4Entry> {
      */
     public int getAvgWidth() {
         return avgWidth;
+    }
+
+    /**
+     * Total calculated width of all the characters
+     *
+     * @return total image width
+     */
+    public int getTotalWidth() {
+        return totalWidth;
     }
 
     @Override

--- a/src/toniarts/openkeeper/tools/convert/bf4/Bf4File.java
+++ b/src/toniarts/openkeeper/tools/convert/bf4/Bf4File.java
@@ -32,9 +32,9 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import javax.imageio.stream.MemoryCacheImageInputStream;
+import toniarts.openkeeper.tools.convert.FileResourceReader;
 import toniarts.openkeeper.tools.convert.IResourceChunkReader;
 import toniarts.openkeeper.tools.convert.IResourceReader;
-import toniarts.openkeeper.tools.convert.FileResourceReader;
 import toniarts.openkeeper.tools.convert.bf4.Bf4Entry.FontEntryFlag;
 
 /**
@@ -47,14 +47,15 @@ import toniarts.openkeeper.tools.convert.bf4.Bf4Entry.FontEntryFlag;
 public class Bf4File implements Iterable<Bf4Entry> {
 
     private static final String BF4_HEADER_IDENTIFIER = "F4FB";
+    private static final int BITS_PER_PIXEL = 4;
+    private static final IndexColorModel COLOR_MODEL;
+
     private final List<Bf4Entry> entries;
     private short maxWidth;
     private short maxHeight;
     private int maxCodePoint = 0;
     private int glyphCount = 0;
     private int avgWidth = 0;
-    private static final int BITS_PER_PIXEL = 4;
-    private static final IndexColorModel COLOR_MODEL;
 
     static {
 

--- a/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertFonts.java
+++ b/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertFonts.java
@@ -36,6 +36,7 @@ import java.util.regex.Pattern;
 import javax.imageio.ImageIO;
 import toniarts.openkeeper.tools.convert.AssetsConverter;
 import toniarts.openkeeper.tools.convert.FontCreator;
+import toniarts.openkeeper.tools.convert.FontCreator.FontImage;
 import toniarts.openkeeper.tools.convert.bf4.Bf4File;
 import toniarts.openkeeper.utils.AssetUtils;
 import toniarts.openkeeper.utils.PathUtils;
@@ -115,12 +116,14 @@ public class ConvertFonts extends ConversionTask {
                 fontSize = Integer.parseInt(matcher.group("size"));
                 String baseFileName = matcher.group("name");
                 baseFileName = destination.concat(Character.toUpperCase(baseFileName.charAt(0)) + baseFileName.substring(1).toLowerCase() + fontSize);
-                imageFileName = baseFileName.concat(".png");
+                imageFileName = baseFileName.substring(destination.length()).concat(".png");
                 descriptionFileName = baseFileName.concat(".fnt");
 
-                // Convert & save the font file
-                FontCreator fc = new FontCreator(new Bf4File(file), fontSize, imageFileName.substring(destination.length()));
-                ImageIO.write(fc.getFontImage(), "png", new File(imageFileName));
+                // Convert & save the font files
+                FontCreator fc = new FontCreator(new Bf4File(file), fontSize, imageFileName);
+                for (FontImage fontImage : fc.getFontImages()) {
+                    ImageIO.write(fontImage.getFontImage(), "png", new File(destination + fontImage.getFileName()));
+                }
                 try (BufferedWriter bw = Files.newBufferedWriter(Paths.get(descriptionFileName), StandardCharsets.UTF_8, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {
                     bw.write(fc.getDescription());
                 }

--- a/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertFonts.java
+++ b/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertFonts.java
@@ -29,6 +29,11 @@ import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
@@ -40,6 +45,7 @@ import toniarts.openkeeper.tools.convert.FontCreator.FontImage;
 import toniarts.openkeeper.tools.convert.bf4.Bf4File;
 import toniarts.openkeeper.utils.AssetUtils;
 import toniarts.openkeeper.utils.PathUtils;
+import toniarts.openkeeper.utils.Utils;
 
 /**
  * Dungeon Keeper II font conversion. Converts all fonts to jME friendly bitmap
@@ -51,13 +57,35 @@ public class ConvertFonts extends ConversionTask {
 
     private static final Logger LOGGER = Logger.getLogger(ConvertFonts.class.getName());
 
+    private final ExecutorService executorService;
+
     public ConvertFonts(String dungeonKeeperFolder, String destination, boolean overwriteData) {
         super(dungeonKeeperFolder, destination, overwriteData);
+
+        this.executorService = Executors.newFixedThreadPool(Utils.MAX_THREADS, new ThreadFactory() {
+
+            private final AtomicInteger threadIndex = new AtomicInteger(0);
+
+            @Override
+            public Thread newThread(Runnable r) {
+                return new Thread(r, "FontsConverter_" + threadIndex.incrementAndGet());
+            }
+
+        });
     }
 
     @Override
     public void internalExecuteTask() {
-        convertFonts(dungeonKeeperFolder, destination);
+        try {
+            convertFonts(dungeonKeeperFolder, destination);
+        } finally {
+            executorService.shutdown();
+            try {
+                executorService.awaitTermination(Long.MAX_VALUE, TimeUnit.DAYS);
+            } catch (InterruptedException ex) {
+                LOGGER.log(Level.SEVERE, "Failed to wait font conversion complete!", ex);
+            }
+        }
     }
 
     /**
@@ -94,47 +122,58 @@ public class ConvertFonts extends ConversionTask {
             });
 
             // Go through the font files
-            int i = 0;
+            AtomicInteger progress = new AtomicInteger(0);
             int total = bf4Files.size();
+            updateStatus(0, total);
             Pattern pattern = Pattern.compile("FONT_(?<name>\\D+)(?<size>\\d+)", Pattern.CASE_INSENSITIVE);
             for (Path file : bf4Files) {
-                updateStatus(i, total);
-
-                // The file names
-                final int fontSize;
-
-                final String imageFileName;
-                final String descriptionFileName;
-                Matcher matcher = pattern.matcher(file.getFileName().toString());
-                boolean found = matcher.find();
-                if (!found) {
-                    LOGGER.log(Level.SEVERE, "Font name {0} not recognized!", file.getFileName());
-                    throw new RuntimeException("Unknown font name!");
-                }
-
-                // Parse font info from the file name
-                fontSize = Integer.parseInt(matcher.group("size"));
-                String baseFileName = matcher.group("name");
-                baseFileName = destination.concat(Character.toUpperCase(baseFileName.charAt(0)) + baseFileName.substring(1).toLowerCase() + fontSize);
-                imageFileName = baseFileName.substring(destination.length()).concat(".png");
-                descriptionFileName = baseFileName.concat(".fnt");
-
-                // Convert & save the font files
-                FontCreator fc = new FontCreator(new Bf4File(file), fontSize, imageFileName);
-                for (FontImage fontImage : fc.getFontImages()) {
-                    ImageIO.write(fontImage.getFontImage(), "png", new File(destination + fontImage.getFileName()));
-                }
-                try (BufferedWriter bw = Files.newBufferedWriter(Paths.get(descriptionFileName), StandardCharsets.UTF_8, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {
-                    bw.write(fc.getDescription());
-                }
-
-                i++;
+                executorService.submit(() -> {
+                    handleFontFile(pattern, file, destination, progress, total);
+                });
             }
 
         } catch (Exception ex) {
-            String msg = "Failed to save the font file to " + destination + "!";
+            String msg = "Failed to save the font files to " + destination + "!";
             LOGGER.log(Level.SEVERE, msg, ex);
             throw new RuntimeException(msg, ex);
+        }
+    }
+
+    private void handleFontFile(Pattern pattern, Path file, final String destination, AtomicInteger progress, int total) {
+        try {
+
+            // The file names
+            final int fontSize;
+            final String imageFileName;
+            final String descriptionFileName;
+            Matcher matcher = pattern.matcher(file.getFileName().toString());
+            boolean found = matcher.find();
+            if (!found) {
+                LOGGER.log(Level.SEVERE, "Font name {0} not recognized!", file.getFileName());
+                throw new RuntimeException("Unknown font name!");
+            }
+
+            // Parse font info from the file name
+            fontSize = Integer.parseInt(matcher.group("size"));
+            String baseFileName = matcher.group("name");
+            baseFileName = destination.concat(Character.toUpperCase(baseFileName.charAt(0)) + baseFileName.substring(1).toLowerCase() + fontSize);
+            imageFileName = baseFileName.substring(destination.length()).concat(".png");
+            descriptionFileName = baseFileName.concat(".fnt");
+
+            // Convert & save the font files
+            FontCreator fc = new FontCreator(new Bf4File(file), fontSize, imageFileName);
+            for (FontImage fontImage : fc.getFontImages()) {
+                ImageIO.write(fontImage.getFontImage(), "png", new File(destination + fontImage.getFileName()));
+            }
+            try (BufferedWriter bw = Files.newBufferedWriter(Paths.get(descriptionFileName), StandardCharsets.UTF_8, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {
+                bw.write(fc.getDescription());
+            }
+
+            updateStatus(progress.incrementAndGet(), total);
+        } catch (Exception ex) {
+            String msg = "Failed to export font file " + file + "!";
+            LOGGER.log(Level.SEVERE, msg, ex);
+            onError(new RuntimeException(msg, ex));
         }
     }
 

--- a/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertFonts.java
+++ b/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertFonts.java
@@ -109,13 +109,14 @@ public class ConvertFonts extends ConversionTask {
                 if (!found) {
                     LOGGER.log(Level.SEVERE, "Font name {0} not recognized!", file.getFileName());
                     throw new RuntimeException("Unknown font name!");
-                } else {
-                    fontSize = Integer.parseInt(matcher.group("size"));
-                    String baseFileName = matcher.group("name");
-                    baseFileName = destination.concat(Character.toUpperCase(baseFileName.charAt(0)) + baseFileName.substring(1).toLowerCase() + fontSize);
-                    imageFileName = baseFileName.concat(".png");
-                    descriptionFileName = baseFileName.concat(".fnt");
                 }
+
+                // Parse font info from the file name
+                fontSize = Integer.parseInt(matcher.group("size"));
+                String baseFileName = matcher.group("name");
+                baseFileName = destination.concat(Character.toUpperCase(baseFileName.charAt(0)) + baseFileName.substring(1).toLowerCase() + fontSize);
+                imageFileName = baseFileName.concat(".png");
+                descriptionFileName = baseFileName.concat(".fnt");
 
                 // Convert & save the font file
                 FontCreator fc = new FontCreator(new Bf4File(file)) {

--- a/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertFonts.java
+++ b/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertFonts.java
@@ -119,17 +119,7 @@ public class ConvertFonts extends ConversionTask {
                 descriptionFileName = baseFileName.concat(".fnt");
 
                 // Convert & save the font file
-                FontCreator fc = new FontCreator(new Bf4File(file)) {
-                    @Override
-                    protected int getFontSize() {
-                        return fontSize;
-                    }
-
-                    @Override
-                    protected String getFileName() {
-                        return imageFileName.substring(destination.length());
-                    }
-                };
+                FontCreator fc = new FontCreator(new Bf4File(file), fontSize, imageFileName.substring(destination.length()));
                 ImageIO.write(fc.getFontImage(), "png", new File(imageFileName));
                 try (BufferedWriter bw = Files.newBufferedWriter(Paths.get(descriptionFileName), StandardCharsets.UTF_8, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {
                     bw.write(fc.getDescription());

--- a/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertModels.java
+++ b/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertModels.java
@@ -44,6 +44,7 @@ import toniarts.openkeeper.tools.convert.kmf.KmfFile;
 import toniarts.openkeeper.tools.convert.wad.WadFile;
 import toniarts.openkeeper.utils.AssetUtils;
 import toniarts.openkeeper.utils.PathUtils;
+import toniarts.openkeeper.utils.Utils;
 
 /**
  * Dungeon Keeper II models conversion. Converts KMF to jME internal optimized
@@ -54,7 +55,6 @@ import toniarts.openkeeper.utils.PathUtils;
 public class ConvertModels extends ConversionTask {
 
     private static final Logger LOGGER = Logger.getLogger(ConvertModels.class.getName());
-    private static final int MAX_THREADS = Runtime.getRuntime().availableProcessors();
 
     private final AssetManager assetManager;
     private final ExecutorService executorService;
@@ -63,7 +63,7 @@ public class ConvertModels extends ConversionTask {
         super(dungeonKeeperFolder, destination, overwriteData);
 
         this.assetManager = assetManager;
-        this.executorService = Executors.newFixedThreadPool(MAX_THREADS, new ThreadFactory() {
+        this.executorService = Executors.newFixedThreadPool(Utils.MAX_THREADS, new ThreadFactory() {
 
             private final AtomicInteger threadIndex = new AtomicInteger(0);
 

--- a/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertTextures.java
+++ b/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertTextures.java
@@ -38,6 +38,7 @@ import toniarts.openkeeper.tools.convert.textures.loadingscreens.LoadingScreenFi
 import toniarts.openkeeper.tools.convert.wad.WadFile;
 import toniarts.openkeeper.utils.AssetUtils;
 import toniarts.openkeeper.utils.PathUtils;
+import toniarts.openkeeper.utils.Utils;
 
 /**
  * Dungeon Keeper II textures conversion. Converts textures to PNG.
@@ -47,14 +48,13 @@ import toniarts.openkeeper.utils.PathUtils;
 public class ConvertTextures extends ConversionTask {
 
     private static final Logger LOGGER = Logger.getLogger(ConvertTextures.class.getName());
-    private static final int MAX_THREADS = Runtime.getRuntime().availableProcessors();
 
     private final ExecutorService executorService;
 
     public ConvertTextures(String dungeonKeeperFolder, String destination, boolean overwriteData) {
         super(dungeonKeeperFolder, destination, overwriteData);
 
-        this.executorService = Executors.newFixedThreadPool(MAX_THREADS, new ThreadFactory() {
+        this.executorService = Executors.newFixedThreadPool(Utils.MAX_THREADS, new ThreadFactory() {
 
             private final AtomicInteger threadIndex = new AtomicInteger(0);
 

--- a/src/toniarts/openkeeper/utils/Utils.java
+++ b/src/toniarts/openkeeper/utils/Utils.java
@@ -100,6 +100,7 @@ public class Utils {
         "Loam", "Prang", "Bane", "Odo", "Smirch", "Orzac", "Tome", "Phestre", "Scurge", "Rictus",
         "Hatchett", "Gewgog", "Slake", "Ratchett", "Threck", "Galen", "Mortis", "Delver"};
 
+    public static final int MAX_THREADS = Runtime.getRuntime().availableProcessors();
     public static final int MAX_CREATURE_LEVEL = 10;
     public static final short[] PLAYER_IDS = new short[]{Player.GOOD_PLAYER_ID, Player.NEUTRAL_PLAYER_ID, Player.KEEPER1_ID, Player.KEEPER2_ID, Player.KEEPER3_ID, Player.KEEPER4_ID, Player.KEEPER5_ID};
 


### PR DESCRIPTION
Makes the fonts used in-game as power of two for maximum compatibility. Also the Japanese fonts are really big, or rather numerous in character count. In lieu support multi-paged fonts and cap the page/texture size to 2048 (also compatibility thing). The implementation is pretty naive and tries to approximate used space and page counts. It works with the given material _perfectly_. Even if it would fail to calculate, it can accommodate to extra page needs dynamically. All the fancy gimmicks are only visible with the Japanese edition. Plain English version fits to single pages.

The font conversion is fairly slow process but it seems to scale fairly well. It is now multi-threaded. Also the actual font resource reading should now have less read counts which should provide some speed boost.