### PR TITLE
Buffered io

### DIFF
--- a/src/toniarts/openkeeper/Main.java
+++ b/src/toniarts/openkeeper/Main.java
@@ -40,9 +40,11 @@ import de.lessvoid.nifty.render.batch.BatchRenderConfiguration;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.awt.image.BufferedImage;
+import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -495,20 +497,29 @@ public class Main extends SimpleApplication {
      * @return array of application icons
      */
     public static BufferedImage[] getApplicationIcons() {
+        ImageIO.setUseCache(false);
         try {
             return new BufferedImage[]{
-                ImageIO.read(Main.class.getResource("/Icons/openkeeper256.png")),
-                ImageIO.read(Main.class.getResource("/Icons/openkeeper128.png")),
-                ImageIO.read(Main.class.getResource("/Icons/openkeeper64.png")),
-                ImageIO.read(Main.class.getResource("/Icons/openkeeper48.png")),
-                ImageIO.read(Main.class.getResource("/Icons/openkeeper32.png")),
-                ImageIO.read(Main.class.getResource("/Icons/openkeeper24.png")),
-                ImageIO.read(Main.class.getResource("/Icons/openkeeper16.png"))
+                readIcon("/Icons/openkeeper256.png"),
+                readIcon("/Icons/openkeeper256.png"),
+                readIcon("/Icons/openkeeper128.png"),
+                readIcon("/Icons/openkeeper64.png"),
+                readIcon("/Icons/openkeeper48.png"),
+                readIcon("/Icons/openkeeper32.png"),
+                readIcon("/Icons/openkeeper24.png"),
+                readIcon("/Icons/openkeeper16.png")
             };
         } catch (IOException ex) {
             LOGGER.log(Level.SEVERE, "Failed to load the application icons!", ex);
         }
         return null;
+    }
+
+    private static BufferedImage readIcon(String path) throws IOException {
+        try (InputStream is = Main.class.getResourceAsStream(path);
+                BufferedInputStream bis = new BufferedInputStream(is)) {
+            return ImageIO.read(bis);
+        }
     }
 
     /**

--- a/src/toniarts/openkeeper/audio/plugins/MP2Loader.java
+++ b/src/toniarts/openkeeper/audio/plugins/MP2Loader.java
@@ -23,6 +23,7 @@ import com.jme3.audio.AudioData;
 import com.jme3.audio.AudioKey;
 import com.jme3.audio.AudioStream;
 import com.jme3.util.BufferUtils;
+import java.io.BufferedInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -51,9 +52,7 @@ public class MP2Loader implements AssetLoader {
     private static final Logger LOGGER = Logger.getLogger(MP2Loader.class.getName());
 
     /**
-     * Masks the real input stream to decode the MP2<br>
-     * The last read repeats a bit, that is a known issue:
-     * http://hub.jmonkeyengine.org/forum/topic/streaming-audio-with-audionode-plays-ending-wrongly/
+     * Masks the real input stream to decode the MP2
      */
     private static class MPxStream extends InputStream {
 
@@ -166,7 +165,7 @@ public class MP2Loader implements AssetLoader {
         AudioData data;
         InputStream inputStream = null;
         try {
-            inputStream = info.openStream();
+            inputStream = new BufferedInputStream(info.openStream());
             data = load(inputStream, ((AudioKey) info.getKey()).isStream());
             if (data instanceof AudioStream) {
                 inputStream = null;

--- a/src/toniarts/openkeeper/game/state/PlayerScreenController.java
+++ b/src/toniarts/openkeeper/game/state/PlayerScreenController.java
@@ -68,7 +68,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.imageio.ImageIO;
 import toniarts.openkeeper.Main;
 import toniarts.openkeeper.game.component.AttackTarget;
 import toniarts.openkeeper.game.component.CreatureAi;
@@ -105,6 +104,7 @@ import toniarts.openkeeper.tools.convert.map.KeeperSpell;
 import toniarts.openkeeper.tools.convert.map.KwdFile;
 import toniarts.openkeeper.tools.convert.map.Room;
 import toniarts.openkeeper.tools.convert.map.Trap;
+import toniarts.openkeeper.utils.AssetUtils;
 import toniarts.openkeeper.utils.Utils;
 import toniarts.openkeeper.view.PlayerInteractionState;
 import toniarts.openkeeper.view.PlayerInteractionState.InteractionState.Type;
@@ -610,7 +610,7 @@ public class PlayerScreenController implements IPlayerScreenController {
 
         // Stretch the background image (height-wise) on the background image panel
         try {
-            BufferedImage img = ImageIO.read(assetManager.locateAsset(new AssetKey("Textures/GUI/Windows/Panel-BG.png")).openStream());
+            BufferedImage img = AssetUtils.readImageFromAsset(assetManager.locateAsset(new AssetKey("Textures/GUI/Windows/Panel-BG.png")));
 
             // Scale the backgroung image to the panel height, keeping the aspect ratio
             Element panel = nifty.getCurrentScreen().findElementById("bottomBackgroundPanel");

--- a/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertFonts.java
+++ b/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertFonts.java
@@ -16,9 +16,10 @@
  */
 package toniarts.openkeeper.tools.convert.conversion.task;
 
+import java.io.BufferedOutputStream;
 import java.io.BufferedWriter;
-import java.io.File;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
@@ -99,6 +100,7 @@ public class ConvertFonts extends ConversionTask {
         updateStatus(null, null);
         Path destFolder = Paths.get(destination);
         AssetUtils.deleteFolder(destFolder);
+        ImageIO.setUseCache(false);
 
         try {
 
@@ -163,7 +165,11 @@ public class ConvertFonts extends ConversionTask {
             // Convert & save the font files
             FontCreator fc = new FontCreator(new Bf4File(file), fontSize, imageFileName);
             for (FontImage fontImage : fc.getFontImages()) {
-                ImageIO.write(fontImage.getFontImage(), "png", new File(destination + fontImage.getFileName()));
+                Path destPath = Paths.get(destination, fontImage.getFileName());
+                try (OutputStream os = Files.newOutputStream(destPath, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+                        BufferedOutputStream bos = new BufferedOutputStream(os)) {
+                    ImageIO.write(fontImage.getFontImage(), "png", bos);
+                }
             }
             try (BufferedWriter bw = Files.newBufferedWriter(Paths.get(descriptionFileName), StandardCharsets.UTF_8, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {
                 bw.write(fc.getDescription());

--- a/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertMapThumbnails.java
+++ b/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertMapThumbnails.java
@@ -17,12 +17,14 @@
 package toniarts.openkeeper.tools.convert.conversion.task;
 
 import java.awt.image.BufferedImage;
-import java.io.File;
+import java.io.BufferedOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
@@ -97,6 +99,7 @@ public class ConvertMapThumbnails extends ConversionTask {
         // Go through the map files
         int i = 0;
         int total = maps.size();
+        ImageIO.setUseCache(false);
         for (KwdFile kwd : maps) {
             updateStatus(i, total);
             try {
@@ -120,7 +123,12 @@ public class ConvertMapThumbnails extends ConversionTask {
         // Create the thumbnail & save it
         // TODO maybe image size in Settings ???
         BufferedImage thumbnail = MapThumbnailGenerator.generateMap(kwd, 144, 144, false);
-        ImageIO.write(thumbnail, "png", new File(destination + ConversionUtils.stripFileName(kwd.getGameLevel().getName()) + ".png"));
+
+        Path destinationPath = Paths.get(destination, ConversionUtils.stripFileName(kwd.getGameLevel().getName()) + ".png");
+        try (OutputStream os = Files.newOutputStream(destinationPath, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+                BufferedOutputStream bos = new BufferedOutputStream(os)) {
+            ImageIO.write(thumbnail, "png", bos);
+        }
     }
 
     @Override

--- a/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertTextures.java
+++ b/src/toniarts/openkeeper/tools/convert/conversion/task/ConvertTextures.java
@@ -16,11 +16,14 @@
  */
 package toniarts.openkeeper.tools.convert.conversion.task;
 
+import java.io.BufferedOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
@@ -189,6 +192,7 @@ public class ConvertTextures extends ConversionTask {
      * @param destination destination directory
      */
     private void extractTextureContainer(AtomicInteger progress, int total, WadFile wad, String destination) {
+        ImageIO.setUseCache(false);
         for (final String entry : wad.getWadFileEntries()) {
 
             // Some of these archives contain .444 files, convert these to PNGs
@@ -197,7 +201,10 @@ public class ConvertTextures extends ConversionTask {
                 try {
                     Path destFile = Paths.get(destination, entry.substring(0, entry.length() - 3).concat("png"));
                     Files.createDirectories(destFile.getParent());
-                    ImageIO.write(lsf.getImage(), "png", destFile.toFile());
+                    try (OutputStream os = Files.newOutputStream(destFile, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+                            BufferedOutputStream bos = new BufferedOutputStream(os)) {
+                        ImageIO.write(lsf.getImage(), "png", bos);
+                    }
                 } catch (IOException ex) {
                     LOGGER.log(Level.SEVERE, "Failed to save the wad entry " + entry + "!", ex);
                     onError(new RuntimeException("Failed to save the wad entry " + entry + "!", ex));

--- a/src/toniarts/openkeeper/tools/convert/textures/enginetextures/EngineTexturesFile.java
+++ b/src/toniarts/openkeeper/tools/convert/textures/enginetextures/EngineTexturesFile.java
@@ -33,9 +33,9 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.imageio.ImageIO;
 import toniarts.openkeeper.tools.convert.ConversionUtils;
+import toniarts.openkeeper.tools.convert.FileResourceReader;
 import toniarts.openkeeper.tools.convert.IResourceChunkReader;
 import toniarts.openkeeper.tools.convert.IResourceReader;
-import toniarts.openkeeper.tools.convert.FileResourceReader;
 
 /**
  * Reads Dungeon Keeper II EngineTextures.dat file to a structure<br>
@@ -225,6 +225,7 @@ public class EngineTexturesFile implements Iterable<String> {
             throw new RuntimeException("File " + textureEntry + " not found from the texture archive!");
         }
 
+        ImageIO.setUseCache(false);
         try {
 
             // We should decompress the texture

--- a/src/toniarts/openkeeper/utils/AssetUtils.java
+++ b/src/toniarts/openkeeper/utils/AssetUtils.java
@@ -40,8 +40,10 @@ import java.awt.AlphaComposite;
 import java.awt.Graphics2D;
 import java.awt.Point;
 import java.awt.image.BufferedImage;
+import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.file.FileVisitResult;
@@ -317,7 +319,7 @@ public class AssetUtils {
         if (resource.getFlags().contains(ArtResource.ArtResourceFlag.ANIMATING_TEXTURE)) {
 
             // Get the first frame, the frames need to be same size
-            BufferedImage img = ImageIO.read(assetManager.locateAsset(new AssetKey(ConversionUtils.getCanonicalAssetKey(assetFolder + resource.getName() + "0.png"))).openStream());
+            BufferedImage img = readImageFromAsset(assetManager.locateAsset(new AssetKey(ConversionUtils.getCanonicalAssetKey(assetFolder + resource.getName() + "0.png"))));
 
             // Create image big enough to fit all the frames
             int frames = resource.getData(ArtResource.KEY_FRAMES);
@@ -335,7 +337,7 @@ public class AssetUtils {
             for (int x = 1; x < frames; x++) {
                 AssetInfo asset = assetManager.locateAsset(new AssetKey(ConversionUtils.getCanonicalAssetKey(assetFolder + resource.getName() + x + ".png")));
                 if (asset != null) {
-                    img = ImageIO.read(asset.openStream());
+                    img = readImageFromAsset(asset);
                 } else {
                     // use previous img
                     LOGGER.log(Level.WARNING, "Animated Texture {0}{1} not found", new Object[]{resource.getName(), x});
@@ -358,6 +360,14 @@ public class AssetUtils {
             // A regular texture
             TextureKey key = new TextureKey(ConversionUtils.getCanonicalAssetKey(assetFolder + resource.getName() + ".png"), false);
             return assetManager.loadTexture(key);
+        }
+    }
+
+    public static BufferedImage readImageFromAsset(AssetInfo asset) throws IOException {
+        ImageIO.setUseCache(false);
+        try (InputStream is = asset.openStream();
+                BufferedInputStream bis = new BufferedInputStream(is)) {
+            return ImageIO.read(bis);
         }
     }
 

--- a/src/toniarts/openkeeper/utils/MapThumbnailGenerator.java
+++ b/src/toniarts/openkeeper/utils/MapThumbnailGenerator.java
@@ -28,7 +28,13 @@ import java.awt.image.IndexColorModel;
 import java.awt.image.PixelInterleavedSampleModel;
 import java.awt.image.Raster;
 import java.awt.image.WritableRaster;
+import java.io.BufferedInputStream;
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
@@ -150,9 +156,10 @@ public class MapThumbnailGenerator {
 
     private static ColorModel readPalette() {
         try {
+            Path palettePath = Paths.get(ConversionUtils.getRealFileName(AssetsConverter.getAssetsFolder(), PALETTE_IMAGE));
 
             // Read the DK II palette image
-            BufferedImage paletteImage = ImageIO.read(new File(ConversionUtils.getRealFileName(AssetsConverter.getAssetsFolder(), PALETTE_IMAGE)));
+            BufferedImage paletteImage = readImageFromPath(palettePath);
 
             // The palette image is generally an image where 1 column represents one color, column width is 1px
             // We know that is is 64x16, but just play along with "dynamic" (we'll fail if it is over 256)
@@ -173,6 +180,14 @@ public class MapThumbnailGenerator {
 
             // TODO: Create a random palette here?
             throw new RuntimeException("Failed to create the map thumbnail palette!", e);
+        }
+    }
+
+    private static BufferedImage readImageFromPath(Path palettePath) throws IOException {
+        ImageIO.setUseCache(false);
+        try (InputStream is = Files.newInputStream(palettePath);
+                BufferedInputStream bis = new BufferedInputStream(is)) {
+            return ImageIO.read(bis);
         }
     }
 

--- a/src/toniarts/openkeeper/world/effect/TorchControl.java
+++ b/src/toniarts/openkeeper/world/effect/TorchControl.java
@@ -46,10 +46,10 @@ import java.awt.image.RGBImageFilter;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.imageio.ImageIO;
 import toniarts.openkeeper.tools.convert.ConversionUtils;
 import toniarts.openkeeper.tools.convert.map.KwdFile;
 import toniarts.openkeeper.tools.convert.map.Variable.MiscVariable.MiscType;
+import toniarts.openkeeper.utils.AssetUtils;
 
 /**
  *
@@ -170,7 +170,7 @@ public class TorchControl extends BillboardControl {
         //float[] offsets = new float[4];
         //RescaleOp rop = new RescaleOp(scales, offsets, null);
         // Get the first frame, the frames need to be same size
-        BufferedImage img = ImageIO.read(assetManager.locateAsset(new AssetKey(ConversionUtils.getCanonicalAssetKey("Textures/" + name + "0.png"))).openStream());
+        BufferedImage img = AssetUtils.readImageFromAsset(assetManager.locateAsset(new AssetKey(ConversionUtils.getCanonicalAssetKey("Textures/" + name + "0.png"))));
 
         // Create image big enough to fit all the frames
         BufferedImage text = new BufferedImage(img.getWidth() * frames, img.getHeight(),
@@ -179,7 +179,7 @@ public class TorchControl extends BillboardControl {
         g.drawImage(makeColorTransparent(img), 0, 0, null);
         for (int x = 1; x < frames; x++) {
             AssetInfo asset = assetManager.locateAsset(new AssetKey(ConversionUtils.getCanonicalAssetKey("Textures/" + name + x + ".png")));
-            img = ImageIO.read(asset.openStream());
+            img = AssetUtils.readImageFromAsset(asset);
             g.drawImage(makeColorTransparent(img), img.getWidth() * x, 0, null);
         }
         g.dispose();


### PR DESCRIPTION
Use ImageIO with buffers, both read and write. Also disable the cache (or rather default to memory cache instead of disk cache). Our audio reader was really heavy reader, now it also uses buffered stream. 

All this makes things a bit more light weight, and it does show... but of course it is not a miracle maker.