### PR TITLE
Texture conversion

### DIFF
--- a/src/toniarts/openkeeper/tools/convert/AssetsConverter.java
+++ b/src/toniarts/openkeeper/tools/convert/AssetsConverter.java
@@ -59,7 +59,7 @@ public abstract class AssetsConverter implements IConversionTaskUpdate {
      */
     public enum ConvertProcess {
 
-        TEXTURES(6, new ConvertProcess[]{}),
+        TEXTURES(7, new ConvertProcess[]{}),
         MODELS(6, new ConvertProcess[]{TEXTURES}),
         MOUSE_CURSORS(4, new ConvertProcess[]{}),
         MUSIC_AND_SOUNDS(4, new ConvertProcess[]{}),

--- a/src/toniarts/openkeeper/tools/convert/textures/ImageUtil.java
+++ b/src/toniarts/openkeeper/tools/convert/textures/ImageUtil.java
@@ -80,9 +80,8 @@ public class ImageUtil {
             }
             buffer.put(pixel);
         }
-        pixels = buffer.array();
 
-        return pixels;
+        return buffer.array();
     }
 
 }

--- a/src/toniarts/openkeeper/tools/convert/textures/ImageUtil.java
+++ b/src/toniarts/openkeeper/tools/convert/textures/ImageUtil.java
@@ -37,6 +37,8 @@ import java.nio.ByteBuffer;
  */
 public class ImageUtil {
 
+    private static final ColorSpace COLOR_SPACE = ColorSpace.getInstance(ColorSpace.CS_sRGB);
+
     public static BufferedImage createImage(int width, int height, boolean hasAlpha, byte[] pixels) {
         int len = 4 * width * height;
         if (!hasAlpha) {
@@ -49,11 +51,11 @@ public class ImageUtil {
         if (hasAlpha) {
             int[] offsets = {0, 1, 2, 3};
             sampleModel = new PixelInterleavedSampleModel(DataBuffer.TYPE_BYTE, width, height, 4, 4 * width, offsets);
-            cm = new ComponentColorModel(ColorSpace.getInstance(ColorSpace.CS_sRGB), new int[]{8, 8, 8, 8}, true, false, ComponentColorModel.TRANSLUCENT, DataBuffer.TYPE_BYTE);
+            cm = new ComponentColorModel(COLOR_SPACE, new int[]{8, 8, 8, 8}, true, false, ComponentColorModel.TRANSLUCENT, DataBuffer.TYPE_BYTE);
         } else {
             int[] offsets = {0, 1, 2};
             sampleModel = new PixelInterleavedSampleModel(DataBuffer.TYPE_BYTE, width, height, 3, 3 * width, offsets);
-            cm = new ComponentColorModel(ColorSpace.getInstance(ColorSpace.CS_sRGB), new int[]{8, 8, 8, 0}, false, false, ComponentColorModel.OPAQUE, DataBuffer.TYPE_BYTE);
+            cm = new ComponentColorModel(COLOR_SPACE, new int[]{8, 8, 8, 0}, false, false, ComponentColorModel.OPAQUE, DataBuffer.TYPE_BYTE);
 
             // The pixel data still contains the alpha pixels, strip them out
             if (pixels.length > len) {

--- a/src/toniarts/openkeeper/tools/convert/textures/ImageUtil.java
+++ b/src/toniarts/openkeeper/tools/convert/textures/ImageUtil.java
@@ -27,6 +27,16 @@ import toniarts.openkeeper.tools.convert.ConversionUtils;
  */
 public class ImageUtil {
 
+    /**
+     * Creates a BufferedImage out of raw byte data
+     *
+     * @param width width of the image
+     * @param height height of the image
+     * @param hasAlpha whether the image should preserve alpha information
+     * @param pixels the raw data, 4 unsigned bytes per pixel (R, G, B, A
+     * respectively)
+     * @return BufferedImage formed from the raw data
+     */
     public static BufferedImage createImage(int width, int height, boolean hasAlpha, byte[] pixels) {
         BufferedImage img = new BufferedImage(width, height, hasAlpha ? BufferedImage.TYPE_INT_ARGB : BufferedImage.TYPE_INT_RGB);
 

--- a/src/toniarts/openkeeper/tools/convert/textures/ImageUtil.java
+++ b/src/toniarts/openkeeper/tools/convert/textures/ImageUtil.java
@@ -37,7 +37,8 @@ import java.nio.ByteBuffer;
  */
 public class ImageUtil {
 
-    private static final ColorSpace COLOR_SPACE = ColorSpace.getInstance(ColorSpace.CS_sRGB);
+    private static final ColorModel COLOR_MODEL = new ComponentColorModel(ColorSpace.getInstance(ColorSpace.CS_sRGB), new int[]{8, 8, 8}, false, false, ComponentColorModel.OPAQUE, DataBuffer.TYPE_BYTE);
+    private static final ColorModel COLOR_MODEL_ALPHA = new ComponentColorModel(ColorSpace.getInstance(ColorSpace.CS_sRGB), new int[]{8, 8, 8, 8}, true, false, ComponentColorModel.TRANSLUCENT, DataBuffer.TYPE_BYTE);
 
     public static BufferedImage createImage(int width, int height, boolean hasAlpha, byte[] pixels) {
         int len = 4 * width * height;
@@ -51,11 +52,11 @@ public class ImageUtil {
         if (hasAlpha) {
             int[] offsets = {0, 1, 2, 3};
             sampleModel = new PixelInterleavedSampleModel(DataBuffer.TYPE_BYTE, width, height, 4, 4 * width, offsets);
-            cm = new ComponentColorModel(COLOR_SPACE, new int[]{8, 8, 8, 8}, true, false, ComponentColorModel.TRANSLUCENT, DataBuffer.TYPE_BYTE);
+            cm = COLOR_MODEL_ALPHA;
         } else {
             int[] offsets = {0, 1, 2};
             sampleModel = new PixelInterleavedSampleModel(DataBuffer.TYPE_BYTE, width, height, 3, 3 * width, offsets);
-            cm = new ComponentColorModel(COLOR_SPACE, new int[]{8, 8, 8, 0}, false, false, ComponentColorModel.OPAQUE, DataBuffer.TYPE_BYTE);
+            cm = COLOR_MODEL;
 
             // The pixel data still contains the alpha pixels, strip them out
             if (pixels.length > len) {

--- a/src/toniarts/openkeeper/tools/convert/textures/ImageUtil.java
+++ b/src/toniarts/openkeeper/tools/convert/textures/ImageUtil.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2014-2021 OpenKeeper
+ *
+ * OpenKeeper is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * OpenKeeper is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenKeeper.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package toniarts.openkeeper.tools.convert.textures;
+
+import java.awt.Point;
+import java.awt.color.ColorSpace;
+import java.awt.image.BufferedImage;
+import java.awt.image.ColorModel;
+import java.awt.image.ComponentColorModel;
+import java.awt.image.DataBuffer;
+import java.awt.image.DataBufferByte;
+import java.awt.image.PixelInterleavedSampleModel;
+import java.awt.image.Raster;
+import java.awt.image.SampleModel;
+import java.awt.image.WritableRaster;
+import java.nio.ByteBuffer;
+
+/**
+ * Helps the texture conversion by creating BufferedImages from the converted
+ * raw data
+ *
+ * @author Toni Helenius <helenius.toni@gmail.com>
+ */
+public class ImageUtil {
+
+    public static BufferedImage createImage(int width, int height, boolean hasAlpha, byte[] pixels) {
+        int len = 4 * width * height;
+        if (!hasAlpha) {
+            len = 3 * width * height;
+        }
+
+        // Draw the image
+        ColorModel cm;
+        SampleModel sampleModel;
+        if (hasAlpha) {
+            int[] offsets = {0, 1, 2, 3};
+            sampleModel = new PixelInterleavedSampleModel(DataBuffer.TYPE_BYTE, width, height, 4, 4 * width, offsets);
+            cm = new ComponentColorModel(ColorSpace.getInstance(ColorSpace.CS_sRGB), new int[]{8, 8, 8, 8}, true, false, ComponentColorModel.TRANSLUCENT, DataBuffer.TYPE_BYTE);
+        } else {
+            int[] offsets = {0, 1, 2};
+            sampleModel = new PixelInterleavedSampleModel(DataBuffer.TYPE_BYTE, width, height, 3, 3 * width, offsets);
+            cm = new ComponentColorModel(ColorSpace.getInstance(ColorSpace.CS_sRGB), new int[]{8, 8, 8, 0}, false, false, ComponentColorModel.OPAQUE, DataBuffer.TYPE_BYTE);
+
+            // The pixel data still contains the alpha pixels, strip them out
+            if (pixels.length > len) {
+                pixels = stripAlphaBytes(len, pixels);
+            }
+        }
+
+        DataBufferByte dataBuffer = new DataBufferByte(pixels, len);
+
+        WritableRaster raster = Raster.createWritableRaster(sampleModel, dataBuffer, new Point(0, 0));
+        BufferedImage img = new BufferedImage(cm, raster, false, null);
+
+        return img;
+    }
+
+    private static byte[] stripAlphaBytes(int len, byte[] pixels) {
+        ByteBuffer buffer = ByteBuffer.allocate(len);
+        int i = 0;
+        for (byte pixel : pixels) {
+            i++;
+            if (i == 4) {
+                i = 0;
+                continue;
+            }
+            buffer.put(pixel);
+        }
+        pixels = buffer.array();
+
+        return pixels;
+    }
+
+}

--- a/src/toniarts/openkeeper/tools/convert/textures/enginetextures/EngineTexturesFile.java
+++ b/src/toniarts/openkeeper/tools/convert/textures/enginetextures/EngineTexturesFile.java
@@ -37,6 +37,7 @@ import toniarts.openkeeper.tools.convert.FileResourceReader;
 import toniarts.openkeeper.tools.convert.IResourceChunkReader;
 import toniarts.openkeeper.tools.convert.IResourceReader;
 import toniarts.openkeeper.tools.convert.ISeekableResourceReader;
+import toniarts.openkeeper.tools.convert.textures.ImageUtil;
 
 /**
  * Reads Dungeon Keeper II EngineTextures.dat file to a structure<br>
@@ -302,7 +303,6 @@ public class EngineTexturesFile implements Iterable<String> {
      * @return
      */
     private BufferedImage decompressTexture(long[] buf, EngineTextureEntry engineTextureEntry) {
-        BufferedImage img = new BufferedImage(engineTextureEntry.getResX(), engineTextureEntry.getResY(), engineTextureEntry.isAlphaFlag() ? BufferedImage.TYPE_INT_ARGB : BufferedImage.TYPE_INT_RGB);
 
         // Decompress the texture
         if (decoder == null) {
@@ -310,19 +310,7 @@ public class EngineTexturesFile implements Iterable<String> {
         }
         byte[] pixels = decoder.dd_texture(buf, engineTextureEntry.getResX() * (32 / 8)/*(bpp / 8 = bytes per pixel)*/, engineTextureEntry.getResX(), engineTextureEntry.getResY(), engineTextureEntry.isAlphaFlag());
 
-        // Draw the image, pixel by pixel
-        for (int x = 0; x < engineTextureEntry.getResX(); x++) {
-            for (int y = 0; y < engineTextureEntry.getResY(); y++) {
-                int base = engineTextureEntry.getResX() * y * 4 + x * 4;
-                int r = ConversionUtils.toUnsignedByte(pixels[base]);
-                int g = ConversionUtils.toUnsignedByte(pixels[base + 1]);
-                int b = ConversionUtils.toUnsignedByte(pixels[base + 2]);
-                int a = ConversionUtils.toUnsignedByte(pixels[base + 3]);
-                int col = (a << 24) | (r << 16) | (g << 8) | b;
-                img.setRGB(x, y, col);
-            }
-        }
-        return img;
+        return ImageUtil.createImage(engineTextureEntry.getResX(), engineTextureEntry.getResY(), engineTextureEntry.isAlphaFlag(), pixels);
     }
 
     @Override

--- a/src/toniarts/openkeeper/tools/convert/textures/loadingscreens/LoadingScreenFile.java
+++ b/src/toniarts/openkeeper/tools/convert/textures/loadingscreens/LoadingScreenFile.java
@@ -19,7 +19,7 @@ package toniarts.openkeeper.tools.convert.textures.loadingscreens;
 import java.awt.image.BufferedImage;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import toniarts.openkeeper.tools.convert.ConversionUtils;
+import toniarts.openkeeper.tools.convert.textures.ImageUtil;
 
 /**
  * Loading and title screens carry the .444 file extension. They are packed with
@@ -55,24 +55,11 @@ public class LoadingScreenFile {
     }
 
     private BufferedImage decompressTexture(long[] data, int width, int height, boolean alphaFlag) {
-        BufferedImage img = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
 
         // Decompress the texture
         byte[] pixels = new LoadingScreenTextureDecoder().dd_texture(data, width * (32 / 8)/*(bpp / 8 = bytes per pixel)*/, width, height, alphaFlag);
 
-        // Draw the image, pixel by pixel
-        for (int x = 0; x < width; x++) {
-            for (int y = 0; y < height; y++) {
-                int base = width * y * 4 + x * 4;
-                int r = ConversionUtils.toUnsignedByte(pixels[base]);
-                int g = ConversionUtils.toUnsignedByte(pixels[base + 1]);
-                int b = ConversionUtils.toUnsignedByte(pixels[base + 2]);
-                int a = ConversionUtils.toUnsignedByte(pixels[base + 3]);
-                int col = (a << 24) | (r << 16) | (g << 8) | b;
-                img.setRGB(x, y, col);
-            }
-        }
-        return img;
+        return ImageUtil.createImage(width, height, alphaFlag, pixels);
     }
 
     /**


### PR DESCRIPTION
Tried to speed up the texture conversion but it seems that going with rasters and whatnots  doesn't make any difference here. At least it looks that way. So this PR just ends up unifying the image creation from the engine textures (including the .444 files). For the .444 this changes things, we now leave out the alpha channel if it is not present (it is _never_ present, these are the big loading and title screens). This saves us about 5% disk space, and small speed boosts from not writing and later needing to read that information.

Small code unification and tiny speed boost.