### PR TITLE
Gradle 7 compatible

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,6 @@ allprojects {
     repositories {
         mavenLocal()
         mavenCentral()
-        jcenter()
         maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
         maven { url "https://oss.sonatype.org/content/repositories/releases/" }
         maven { url "https://jitpack.io" }
@@ -56,10 +55,10 @@ dependencies {
     implementation "org.jmonkeyengine:jme3-niftygui:$jmonkeyengine_version"
     implementation "com.badlogicgames.gdx:gdx-ai:1.8.2"
     implementation "javax.vecmath:vecmath:1.5.2"
-    implementation "com.simsilica:zay-es:1.3.2"
-    implementation "com.simsilica:zay-es-net:1.4.3"
-    implementation "com.simsilica:sio2:1.6.0"
-    implementation "com.simsilica:sim-ethereal:1.6.0"
+    implementation "com.simsilica:zay-es:1.4.0"
+    implementation "com.simsilica:zay-es-net:1.5.0"
+    implementation "com.simsilica:sio2:1.7.0"
+    implementation "com.simsilica:sim-ethereal:1.7.0"
 }
 
 sourceSets {
@@ -79,7 +78,7 @@ jar {
         attributes(
             'Implementation-Title': project.name,
             'Class-Path': configurations.runtimeClasspath.files.collect { it.getName() }.join(' '),
-            'Main-Class': application.mainClassName,
+            'Main-Class': application.mainClass,
             'Built-By': System.properties['user.name'],
             'Build-Timestamp': new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ").format(new Date()),
             'Created-By': "Gradle ${gradle.gradleVersion}",

--- a/gradlew
+++ b/gradlew
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 #
-# Copyright © 2015-2021 the original authors.
+# Copyright Â© 2015-2021 the original authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,10 +32,10 @@
 #       Busybox and similar reduced shells will NOT work, because this script
 #       requires all of these POSIX shell features:
 #         * functions;
-#         * expansions «$var», «${var}», «${var:-default}», «${var+SET}»,
-#           «${var#prefix}», «${var%suffix}», and «$( cmd )»;
-#         * compound commands having a testable exit status, especially «case»;
-#         * various built-in commands including «command», «set», and «ulimit».
+#         * expansions Â«$varÂ», Â«${var}Â», Â«${var:-default}Â», Â«${var+SET}Â»,
+#           Â«${var#prefix}Â», Â«${var%suffix}Â», and Â«$( cmd )Â»;
+#         * compound commands having a testable exit status, especially Â«caseÂ»;
+#         * various built-in commands including Â«commandÂ», Â«setÂ», and Â«ulimitÂ».
 #
 #   Important for patching:
 #


### PR DESCRIPTION
Removes all the warnings and deprecations from the build. Upgrades the 3rd party libraries now available from MavenCentral.

Gradle 7 is not yet too well supported so that will be later then. Maybe together with Java 17...