### PR TITLE
Use the new Java Date/Time API

### DIFF
--- a/src/toniarts/openkeeper/game/task/AbstractTask.java
+++ b/src/toniarts/openkeeper/game/task/AbstractTask.java
@@ -19,7 +19,7 @@ package toniarts.openkeeper.game.task;
 import com.jme3.math.Vector2f;
 import com.simsilica.es.EntityId;
 import java.awt.Point;
-import java.util.Date;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
@@ -39,14 +39,14 @@ public abstract class AbstractTask implements Task {
     private static final AtomicLong ID_GENENERATOR = new AtomicLong();
 
     private final long id;
-    private final Date taskCreated;
+    private final Instant taskCreated;
     protected final INavigationService navigationService;
     protected final IMapController mapController;
     private final Map<ICreatureController, Float> assignees = new HashMap<>();
     private static final Logger LOGGER = Logger.getLogger(AbstractTask.class.getName());
 
     public AbstractTask(final INavigationService navigationService, final IMapController mapController) {
-        this.taskCreated = new Date();
+        this.taskCreated = Instant.now();
         this.navigationService = navigationService;
         this.mapController = mapController;
         this.id = ID_GENENERATOR.getAndIncrement();
@@ -78,7 +78,7 @@ public abstract class AbstractTask implements Task {
     }
 
     @Override
-    public Date getTaskCreated() {
+    public Instant getTaskCreated() {
         return taskCreated;
     }
 

--- a/src/toniarts/openkeeper/game/task/Task.java
+++ b/src/toniarts/openkeeper/game/task/Task.java
@@ -19,7 +19,7 @@ package toniarts.openkeeper.game.task;
 import com.jme3.math.Vector2f;
 import com.simsilica.es.EntityId;
 import java.awt.Point;
-import java.util.Date;
+import java.time.Instant;
 import toniarts.openkeeper.game.controller.creature.ICreatureController;
 
 /**
@@ -93,7 +93,7 @@ public interface Task {
      */
     Vector2f getTarget(ICreatureController creature);
 
-    Date getTaskCreated();
+    Instant getTaskCreated();
 
     /**
      * Task location, the task it self not necessarily the target for navigating

--- a/src/toniarts/openkeeper/game/task/objective/ObjectiveTaskDecorator.java
+++ b/src/toniarts/openkeeper/game/task/objective/ObjectiveTaskDecorator.java
@@ -19,8 +19,8 @@ package toniarts.openkeeper.game.task.objective;
 import com.jme3.math.Vector2f;
 import com.simsilica.es.EntityId;
 import java.awt.Point;
+import java.time.Instant;
 import java.util.ArrayDeque;
-import java.util.Date;
 import java.util.Deque;
 import toniarts.openkeeper.game.controller.creature.ICreatureController;
 import toniarts.openkeeper.game.task.Task;
@@ -101,7 +101,7 @@ public class ObjectiveTaskDecorator implements ObjectiveTask {
     }
 
     @Override
-    public Date getTaskCreated() {
+    public Instant getTaskCreated() {
         return task.getTaskCreated();
     }
 

--- a/src/toniarts/openkeeper/tools/convert/IResourceChunkReader.java
+++ b/src/toniarts/openkeeper/tools/convert/IResourceChunkReader.java
@@ -18,7 +18,7 @@ package toniarts.openkeeper.tools.convert;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.EnumSet;
 import java.util.List;
 
@@ -115,7 +115,7 @@ public interface IResourceChunkReader extends Comparable<ByteBuffer> {
      * @return the date in current locale
      * @throws java.io.IOException
      */
-    Date readTimestamp() throws IOException;
+    LocalDateTime readTimestamp() throws IOException;
 
     short readUnsignedByte();
 

--- a/src/toniarts/openkeeper/tools/convert/ResourceChunkReader.java
+++ b/src/toniarts/openkeeper/tools/convert/ResourceChunkReader.java
@@ -18,13 +18,11 @@ package toniarts.openkeeper.tools.convert;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Date;
 import java.util.EnumSet;
 import java.util.List;
-import java.util.TimeZone;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -154,18 +152,26 @@ public class ResourceChunkReader implements IResourceChunkReader {
     }
 
     @Override
-    public Date readTimestamp() throws IOException {
-        Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
-        cal.set(Calendar.YEAR, readUnsignedShort());
-        cal.set(Calendar.DAY_OF_MONTH, readUnsignedByte());
-        cal.set(Calendar.MONTH, readUnsignedByte());
+    public LocalDateTime readTimestamp() throws IOException {
+        int year = readUnsignedShort();
+        int dayOfMonth = readUnsignedByte();
+        int month = readUnsignedByte();
+
         skipBytes(2);
-        cal.set(Calendar.HOUR_OF_DAY, readUnsignedByte());
-        cal.set(Calendar.MINUTE, readUnsignedByte());
-        cal.set(Calendar.SECOND, readUnsignedByte());
+
+        int hour = readUnsignedByte();
+        int minute = readUnsignedByte();
+        int second = readUnsignedByte();
+
         skipBytes(1);
 
-        return cal.getTime();
+        if (year == 0) {
+
+            // Null timestamp
+            return null;
+        }
+
+        return LocalDateTime.of(year, month, dayOfMonth, hour, minute, second, 0);
     }
 
     @Override

--- a/src/toniarts/openkeeper/tools/convert/map/KwdFile.java
+++ b/src/toniarts/openkeeper/tools/convert/map/KwdFile.java
@@ -20,10 +20,10 @@ import java.awt.Color;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -3292,8 +3292,8 @@ public final class KwdFile {
         private int dataSizeLevel; // in Level size of data exclude paths
         private int unknown; // only in Triggers and Level
         private int headerEndOffset; // 28, *Map - 8, *Triggers - 32,
-        private Date dateCreated;
-        private Date dateModified;
+        private LocalDateTime dateCreated;
+        private LocalDateTime dateModified;
         private int checkTwo;
         private int dataSize;
 
@@ -3372,19 +3372,19 @@ public final class KwdFile {
             return checkTwo;
         }
 
-        public Date getDateCreated() {
+        public LocalDateTime getDateCreated() {
             return dateCreated;
         }
 
-        protected void setDateCreated(Date date) {
+        protected void setDateCreated(LocalDateTime date) {
             this.dateCreated = date;
         }
 
-        public Date getDateModified() {
+        public LocalDateTime getDateModified() {
             return dateModified;
         }
 
-        protected void setDateModified(Date date) {
+        protected void setDateModified(LocalDateTime date) {
             this.dateModified = date;
         }
 


### PR DESCRIPTION
Use the _new_ Java Date/Time API... from Java 8. Sorry for being such a late bloomer :)

Tasks now use Instant rather than Date. This is actually a kinda bug fix even. The tasks could even go broke when automatically changing DST. Or in the future loading a saved game on another timezone, or just changing your timezone... Well, you get the drift, using date here is just stupid, always was.

What comes to KWD timestamps... This has been broken all along.

- We assumed that the timestamp is in UTC. I tried this with the map editor. The timestamp is always the local time. And there is no timezone information (that I'm aware of). So we have no way of actually getting accurate timestamp.
- The months actually are from 1-12. With the old API 0-11 is assumed. The month was always off by one.
- There is no timestamp available on all files. We now reflect this and parse it as null rather than giving it some value.