### PR TITLE
Feature/graphics options

### DIFF
--- a/src/toniarts/openkeeper/game/data/Settings.java
+++ b/src/toniarts/openkeeper/game/data/Settings.java
@@ -267,10 +267,6 @@ public class Settings {
         // Init the settings
         this.settings = settings;
 
-        //Default resolution
-        if (!this.settings.containsKey("Width") || !this.settings.containsKey("Height")) {
-            this.settings.setResolution(800, 600); // Default resolution
-        }
         if (Files.exists(USER_SETTINGS_FILE)) {
             try (InputStream in = Files.newInputStream(USER_SETTINGS_FILE);
                     BufferedInputStream bin = new BufferedInputStream(in)) {

--- a/src/toniarts/openkeeper/game/data/Settings.java
+++ b/src/toniarts/openkeeper/game/data/Settings.java
@@ -284,6 +284,9 @@ public class Settings {
         // Assing some app level settings
         settings.setTitle(TITLE);
         settings.setIcons(getApplicationIcons());
+
+        // We don't allow this to be changed, assets were not meant to use this
+        settings.setGammaCorrection(false);
     }
 
     /**

--- a/src/toniarts/openkeeper/game/state/MainMenuScreenController.java
+++ b/src/toniarts/openkeeper/game/state/MainMenuScreenController.java
@@ -42,8 +42,6 @@ import de.lessvoid.nifty.render.NiftyImage;
 import de.lessvoid.nifty.screen.Screen;
 import de.lessvoid.nifty.tools.Color;
 import de.lessvoid.nifty.tools.SizeValue;
-import java.awt.GraphicsDevice;
-import java.awt.GraphicsEnvironment;
 import java.io.File;
 import java.io.IOException;
 import java.lang.System.Logger;
@@ -84,6 +82,8 @@ import toniarts.openkeeper.tools.convert.map.GameLevel;
 import toniarts.openkeeper.tools.convert.map.KwdFile;
 import toniarts.openkeeper.tools.modelviewer.SoundsLoader;
 import toniarts.openkeeper.utils.AssetUtils;
+import toniarts.openkeeper.utils.DisplayMode;
+import toniarts.openkeeper.utils.DisplayModeUtils;
 import toniarts.openkeeper.utils.PathUtils;
 import toniarts.openkeeper.utils.Utils;
 
@@ -271,7 +271,7 @@ public class MainMenuScreenController implements IMainMenuScreenController {
         DropDown aa = screen.findNiftyControl("antialiasing", DropDown.class);
         DropDown af = screen.findNiftyControl("anisotropicFiltering", DropDown.class);
         CheckBox ssao = screen.findNiftyControl("ssao", CheckBox.class);
-        MyDisplayMode mdm = (MyDisplayMode) res.getSelection();
+        DisplayMode mdm = (DisplayMode) res.getSelection();
 
         // TODO: See if we need a restart, but keep in mind that the settings are saved in the restart
         // Set the settings
@@ -568,7 +568,7 @@ public class MainMenuScreenController implements IMainMenuScreenController {
     }
 
     @NiftyEventSubscriber(id = "resolution")
-    public void onResolutionChanged(final String id, final DropDownSelectionChangedEvent<MyDisplayMode> event) {
+    public void onResolutionChanged(final String id, final DropDownSelectionChangedEvent<DisplayMode> event) {
 
         // Set the bit depths
         DropDown bitDepth = screen.findNiftyControl("bitDepth", DropDown.class);
@@ -729,9 +729,8 @@ public class MainMenuScreenController implements IMainMenuScreenController {
         // Application settings
         AppSettings settings = Main.getUserSettings().getAppSettings();
 
-        GraphicsDevice device = GraphicsEnvironment.getLocalGraphicsEnvironment().getDefaultScreenDevice();
-        MyDisplayMode mdm = new MyDisplayMode(settings);
-        List<MyDisplayMode> resolutions = state.getResolutions(device);
+        DisplayMode mdm = new DisplayMode(settings);
+        List<DisplayMode> resolutions = DisplayModeUtils.getInstance().getDisplayModes();
         int resolutionSelectedIndex = Collections.binarySearch(resolutions, mdm);
 
         // Get values to the settings screen
@@ -762,7 +761,7 @@ public class MainMenuScreenController implements IMainMenuScreenController {
         // Fullscreen
         CheckBox fullscreen = screen.findNiftyControl("fullscreen", CheckBox.class);
         fullscreen.setChecked(settings.isFullscreen());
-        fullscreen.setEnabled(device.isFullScreenSupported());
+        fullscreen.setEnabled(DisplayModeUtils.getInstance().isFullScreenSupported());
 
         // VSync
         CheckBox vsync = screen.findNiftyControl("verticalSync", CheckBox.class);

--- a/src/toniarts/openkeeper/game/state/MainMenuState.java
+++ b/src/toniarts/openkeeper/game/state/MainMenuState.java
@@ -31,16 +31,12 @@ import com.jme3.scene.Node;
 import com.simsilica.es.EntityData;
 import com.simsilica.es.EntityId;
 import com.simsilica.es.base.DefaultEntityData;
-import java.awt.DisplayMode;
-import java.awt.GraphicsDevice;
 import java.io.File;
 import java.io.IOException;
 import java.lang.System.Logger;
 import java.lang.System.Logger.Level;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
 import toniarts.openkeeper.Main;
 import static toniarts.openkeeper.Main.getDkIIFolder;
 import toniarts.openkeeper.cinematics.CameraSweepData;
@@ -530,38 +526,6 @@ public class MainMenuState extends AbstractAppState {
             levelBriefing.stop();
         }
         levelBriefing = null;
-    }
-
-    /**
-     * Gets the resolutions supported by the given device. The resolutions are
-     * sorted by their native order
-     *
-     * @param device the graphics device to query resolutions from
-     * @return sorted list of available resolutions
-     */
-    protected List<MyDisplayMode> getResolutions(GraphicsDevice device) {
-
-        // Get from the system
-        DisplayMode[] modes = device.getDisplayModes();
-
-        List<MyDisplayMode> displayModes = new ArrayList<>(modes.length);
-
-        // Loop them through
-        for (DisplayMode dm : modes) {
-
-            // They may already exist, then just add the possible resfresh rate
-            MyDisplayMode mdm = new MyDisplayMode(dm);
-            int index = Collections.binarySearch(displayModes, mdm);
-            if (index > -1) {
-                mdm = displayModes.get(index);
-                mdm.addRefreshRate(dm);
-                mdm.addBitDepth(dm);
-            } else {
-                displayModes.add(~index, mdm);
-            }
-        }
-
-        return displayModes;
     }
 
     public void doDebriefing(GameResult result) {

--- a/src/toniarts/openkeeper/utils/AwtDisplayModeProvider.java
+++ b/src/toniarts/openkeeper/utils/AwtDisplayModeProvider.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2014-2024 OpenKeeper
+ *
+ * OpenKeeper is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * OpenKeeper is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenKeeper.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package toniarts.openkeeper.utils;
+
+import java.awt.GraphicsDevice;
+import java.awt.GraphicsEnvironment;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Uses Java's own way of getting available display modes. Often errorenious and
+ * locks up on MacOS with LWJGL 3
+ *
+ * @author Toni Helenius <helenius.toni@gmail.com>
+ */
+class AwtDisplayModeProvider extends DefaultDisplayModeProvider {
+
+    public AwtDisplayModeProvider() {
+    }
+
+    @Override
+    public List<DisplayMode> getDisplayModes() {
+        GraphicsDevice device = getGraphicsDevice();
+
+        java.awt.DisplayMode[] modes = device.getDisplayModes();
+
+        List<DisplayMode> displayModes = new ArrayList<>(modes.length);
+
+        // Loop them through
+        for (java.awt.DisplayMode dm : modes) {
+            DisplayMode mdm = getDisplayMode(dm);
+            addDisplayMode(displayModes, mdm);
+        }
+
+        return displayModes;
+    }
+
+    private GraphicsDevice getGraphicsDevice() {
+        return GraphicsEnvironment.getLocalGraphicsEnvironment().getDefaultScreenDevice();
+    }
+
+    private DisplayMode getDisplayMode(java.awt.DisplayMode dm) {
+        DisplayMode displayMode = new DisplayMode(dm.getWidth(), dm.getHeight());
+        if (dm.getRefreshRate() != java.awt.DisplayMode.REFRESH_RATE_UNKNOWN) {
+            displayMode.addRefreshRate(dm.getRefreshRate());
+        }
+        if (dm.getBitDepth() != java.awt.DisplayMode.BIT_DEPTH_MULTI) {
+            displayMode.addBitDepth(dm.getBitDepth());
+        }
+
+        return displayMode;
+    }
+
+    @Override
+    public boolean isFullScreenSupported() {
+        GraphicsDevice device = getGraphicsDevice();
+
+        return device.isFullScreenSupported();
+    }
+
+}

--- a/src/toniarts/openkeeper/utils/DefaultDisplayModeProvider.java
+++ b/src/toniarts/openkeeper/utils/DefaultDisplayModeProvider.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2014-2024 OpenKeeper
+ *
+ * OpenKeeper is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * OpenKeeper is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenKeeper.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package toniarts.openkeeper.utils;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Simple groups some common methods for display mode providers
+ *
+ * @author Toni Helenius <helenius.toni@gmail.com>
+ */
+abstract class DefaultDisplayModeProvider implements DisplayModeProvider {
+
+    protected void addDisplayMode(List<DisplayMode> displayModes, DisplayMode mdm) {
+        int index = Collections.binarySearch(displayModes, mdm);
+        if (index > -1) {
+            DisplayMode existingDm = displayModes.get(index);
+            for (Integer refreshRate : mdm.getRefreshRates()) {
+                existingDm.addRefreshRate(refreshRate);
+            }
+            for (Integer bitDepth : mdm.getBitDepths()) {
+                existingDm.addBitDepth(bitDepth);
+            }
+        } else {
+            displayModes.add(~index, mdm);
+        }
+    }
+
+}

--- a/src/toniarts/openkeeper/utils/DisplayMode.java
+++ b/src/toniarts/openkeeper/utils/DisplayMode.java
@@ -14,48 +14,43 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenKeeper.  If not, see <http://www.gnu.org/licenses/>.
  */
-package toniarts.openkeeper.game.state;
+package toniarts.openkeeper.utils;
 
 import com.jme3.system.AppSettings;
-import java.awt.DisplayMode;
 import java.util.Collection;
+import java.util.Set;
 import java.util.TreeSet;
 
 /**
+ * Our own presentation of display mode. Groups everything under resolution.
  *
  * @author ArchDemon
  */
-public final class MyDisplayMode implements Comparable<MyDisplayMode> {
+public final class DisplayMode implements Comparable<DisplayMode> {
 
-    private final int height;
     private final int width;
-    private final Collection<Integer> refreshRates = new TreeSet<>();
-    private final Collection<Integer> bitDepths = new TreeSet<>();
+    private final int height;
+    private final Set<Integer> refreshRates = new TreeSet<>();
+    private final Set<Integer> bitDepths = new TreeSet<>();
 
-    public MyDisplayMode(DisplayMode dm) {
-        height = dm.getHeight();
-        width = dm.getWidth();
-        addBitDepth(dm);
-        addRefreshRate(dm);
+    public DisplayMode(int width, int height) {
+        this.width = width;
+        this.height = height;
     }
 
-    MyDisplayMode(AppSettings settings) {
+    public DisplayMode(AppSettings settings) {
         height = settings.getHeight();
         width = settings.getWidth();
         bitDepths.add(settings.getBitsPerPixel());
         refreshRates.add(settings.getFrequency());
     }
 
-    public void addRefreshRate(DisplayMode dm) {
-        if (dm.getRefreshRate() != DisplayMode.REFRESH_RATE_UNKNOWN && !refreshRates.contains(dm.getRefreshRate())) {
-            refreshRates.add(dm.getRefreshRate());
-        }
+    protected void addRefreshRate(Integer refreshRate) {
+        refreshRates.add(refreshRate);
     }
 
-    public void addBitDepth(DisplayMode dm) {
-        if (dm.getBitDepth() != DisplayMode.BIT_DEPTH_MULTI && !bitDepths.contains(dm.getBitDepth())) {
-            bitDepths.add(dm.getBitDepth());
-        }
+    protected void addBitDepth(Integer bitDepth) {
+        bitDepths.add(bitDepth);
     }
 
     public int getWidth() {
@@ -67,9 +62,6 @@ public final class MyDisplayMode implements Comparable<MyDisplayMode> {
     }
 
     public Collection<Integer> getBitDepths() {
-        if (bitDepths.isEmpty()) {
-            bitDepths.add(24); // Add default
-        }
         return bitDepths;
     }
 
@@ -85,7 +77,7 @@ public final class MyDisplayMode implements Comparable<MyDisplayMode> {
         if (getClass() != obj.getClass()) {
             return false;
         }
-        final MyDisplayMode other = (MyDisplayMode) obj;
+        final DisplayMode other = (DisplayMode) obj;
         if (this.height != other.height) {
             return false;
         }
@@ -106,7 +98,7 @@ public final class MyDisplayMode implements Comparable<MyDisplayMode> {
     }
 
     @Override
-    public int compareTo(MyDisplayMode o) {
+    public int compareTo(DisplayMode o) {
         int result = Integer.compare(width, o.width);
         if (result == 0) {
             result = Integer.compare(height, o.height);

--- a/src/toniarts/openkeeper/utils/DisplayModeProvider.java
+++ b/src/toniarts/openkeeper/utils/DisplayModeProvider.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2014-2024 OpenKeeper
+ *
+ * OpenKeeper is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * OpenKeeper is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenKeeper.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package toniarts.openkeeper.utils;
+
+import java.util.List;
+
+/**
+ *
+ * @author Toni Helenius <helenius.toni@gmail.com>
+ */
+public interface DisplayModeProvider {
+
+    /**
+     * Gets the diplay modes supported by the current device. The resolutions
+     * are sorted by their native order
+     *
+     * @return sorted list of available display modes
+     */
+    List<DisplayMode> getDisplayModes();
+
+    boolean isFullScreenSupported();
+}

--- a/src/toniarts/openkeeper/utils/DisplayModeUtils.java
+++ b/src/toniarts/openkeeper/utils/DisplayModeUtils.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2014-2024 OpenKeeper
+ *
+ * OpenKeeper is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * OpenKeeper is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenKeeper.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package toniarts.openkeeper.utils;
+
+import java.util.List;
+
+/**
+ * Java's own graphics settings are more often wrong than right. Also they block
+ * MacOS from working (AWT & LWJGL 3 issue). This class tries to probe either
+ * LWJGL 2 or 3 depending which is available without creating a dependency to
+ * either. Finally falling back to AWT as a last resort.
+ *
+ * @author Toni Helenius <helenius.toni@gmail.com>
+ */
+public class DisplayModeUtils implements DisplayModeProvider {
+
+    /**
+     * The delegate for the actual provider
+     */
+    private final DisplayModeProvider displayModeProvider;
+
+    private static class SingletonHelper {
+
+        private static final DisplayModeUtils INSTANCE = new DisplayModeUtils();
+    }
+
+    public static DisplayModeUtils getInstance() {
+        return SingletonHelper.INSTANCE;
+    }
+
+    private DisplayModeUtils() {
+        displayModeProvider = getDisplayModeProvider();
+    }
+
+    private DisplayModeProvider getDisplayModeProvider() {
+
+        // LWJGL 3
+        try {
+            Class.forName("com.jme3.system.lwjgl.LwjglWindow");
+            return new Lwjgl3DisplayModeProvider();
+        } catch (ClassNotFoundException exception) {
+        }
+
+        // LWJGL 2
+        try {
+            Class.forName("org.lwjgl.opengl.Display");
+            return new Lwjgl2DisplayModeProvider();
+        } catch (ClassNotFoundException exception) {
+        }
+
+        // Fallback
+        return new AwtDisplayModeProvider();
+    }
+
+    @Override
+    public List<DisplayMode> getDisplayModes() {
+        return displayModeProvider.getDisplayModes();
+    }
+
+    @Override
+    public boolean isFullScreenSupported() {
+        return displayModeProvider.isFullScreenSupported();
+    }
+
+}

--- a/src/toniarts/openkeeper/utils/Lwjgl2DisplayModeProvider.java
+++ b/src/toniarts/openkeeper/utils/Lwjgl2DisplayModeProvider.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2014-2024 OpenKeeper
+ *
+ * OpenKeeper is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * OpenKeeper is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenKeeper.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package toniarts.openkeeper.utils;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Extracts display modes using LWJGL 2
+ *
+ * @author Toni Helenius <helenius.toni@gmail.com>
+ */
+class Lwjgl2DisplayModeProvider extends DefaultDisplayModeProvider {
+
+    private final Method getBitsPerPixel;
+    private final Method getFrequency;
+    private final Method getModeHeight;
+    private final Method getModeWidth;
+    private final Method getModes;
+
+    public Lwjgl2DisplayModeProvider() {
+        try {
+            Class<?> displayClass = Class.forName("org.lwjgl.opengl.Display");
+            getModes = displayClass.getDeclaredMethod("getAvailableDisplayModes");
+            Class<?> displayModeClass = Class.forName("org.lwjgl.opengl.DisplayMode");
+            getBitsPerPixel = displayModeClass.getDeclaredMethod("getBitsPerPixel");
+            getFrequency = displayModeClass.getDeclaredMethod("getFrequency");
+            getModeHeight = displayModeClass.getDeclaredMethod("getHeight");
+            getModeWidth = displayModeClass.getDeclaredMethod("getWidth");
+        } catch (ClassNotFoundException | NoSuchMethodException | SecurityException ex) {
+            throw new RuntimeException("Failed to instantiate LWJGL 2 display mode provider. Has API been changed?", ex);
+        }
+    }
+
+    @Override
+    public List<DisplayMode> getDisplayModes() {
+        try {
+            Object[] glModes = (Object[]) getModes.invoke(null);
+
+            List<DisplayMode> displayModes = new ArrayList<>();
+            for (Object glMode : glModes) {
+                DisplayMode mode = getDisplayMode(glMode);
+                addDisplayMode(displayModes, mode);
+            }
+
+            return displayModes;
+        } catch (IllegalAccessException | InvocationTargetException ex) {
+            throw new RuntimeException("Failed to get display modes from LWJGL 2", ex);
+        }
+    }
+
+    private DisplayMode getDisplayMode(Object glMode)
+            throws IllegalAccessException, InvocationTargetException {
+        int width = (Integer) getModeWidth.invoke(glMode);
+        int height = (Integer) getModeHeight.invoke(glMode);
+        int bitDepth = (Integer) getBitsPerPixel.invoke(glMode);
+        int rate = (Integer) getFrequency.invoke(glMode);
+
+        DisplayMode dm = new DisplayMode(width, height);
+        dm.addRefreshRate(rate);
+        dm.addBitDepth(bitDepth);
+
+        return dm;
+    }
+
+    @Override
+    public boolean isFullScreenSupported() {
+        return true;
+    }
+
+}

--- a/src/toniarts/openkeeper/utils/Lwjgl3DisplayModeProvider.java
+++ b/src/toniarts/openkeeper/utils/Lwjgl3DisplayModeProvider.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2014-2024 OpenKeeper
+ *
+ * OpenKeeper is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * OpenKeeper is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenKeeper.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package toniarts.openkeeper.utils;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Extracts display modes using LWJGL 3
+ *
+ * @author Toni Helenius <helenius.toni@gmail.com>
+ */
+class Lwjgl3DisplayModeProvider extends DefaultDisplayModeProvider {
+
+    private final Method get;
+    private final Method getBlueBits;
+    private final Method getFrequency;
+    private final Method getGreenBits;
+    private final Method getModeHeight;
+    private final Method getModeWidth;
+    private final Method getModes;
+    private final Method getPrimaryMonitor;
+    private final Method getRedBits;
+    private final Method hasRemaining;
+
+    public Lwjgl3DisplayModeProvider() {
+        try {
+            Class<?> glfwClass = Class.forName("org.lwjgl.glfw.GLFW");
+            getModes = glfwClass.getDeclaredMethod("glfwGetVideoModes", long.class);
+            getPrimaryMonitor = glfwClass.getDeclaredMethod("glfwGetPrimaryMonitor");
+
+            Class<?> vidModeClass = Class.forName("org.lwjgl.glfw.GLFWVidMode");
+            getBlueBits = vidModeClass.getDeclaredMethod("blueBits");
+            getFrequency = vidModeClass.getDeclaredMethod("refreshRate");
+            getGreenBits = vidModeClass.getDeclaredMethod("greenBits");
+            getModeHeight = vidModeClass.getDeclaredMethod("height");
+            getModeWidth = vidModeClass.getDeclaredMethod("width");
+            getRedBits = vidModeClass.getDeclaredMethod("redBits");
+
+            Class<?>[] vmInnerClasses = vidModeClass.getDeclaredClasses();
+            assert vmInnerClasses.length == 1 : vmInnerClasses.length;
+            Class<?> vmBufferClass = vmInnerClasses[0];
+            get = vmBufferClass.getMethod("get");
+            hasRemaining = vmBufferClass.getMethod("hasRemaining");
+        } catch (ClassNotFoundException | NoSuchMethodException | SecurityException ex) {
+            throw new RuntimeException("Failed to instantiate LWJGL 3 display mode provider. Has API been changed?", ex);
+        }
+    }
+
+    @Override
+    public List<DisplayMode> getDisplayModes() {
+        try {
+            Object monitorId = getPrimaryMonitor.invoke(null);
+
+            if (monitorId == null || 0L == (Long) monitorId) {
+                return Collections.emptyList();
+            }
+
+            Object buf = getModes.invoke(null, monitorId);
+
+            List<DisplayMode> displayModes = new ArrayList<>();
+            while ((Boolean) hasRemaining.invoke(buf)) {
+                Object vidMode = get.invoke(buf);
+
+                DisplayMode mode = getDisplayMode(vidMode);
+                addDisplayMode(displayModes, mode);
+            }
+
+            return displayModes;
+        } catch (IllegalAccessException | InvocationTargetException ex) {
+            throw new RuntimeException("Failed to get display modes from LWJGL 3", ex);
+        }
+    }
+
+    private DisplayMode getDisplayMode(Object glfwVidMode)
+            throws IllegalAccessException, InvocationTargetException {
+        int width = (Integer) getModeWidth.invoke(glfwVidMode);
+        int height = (Integer) getModeHeight.invoke(glfwVidMode);
+        int redBits = (Integer) getRedBits.invoke(glfwVidMode);
+        int greenBits = (Integer) getGreenBits.invoke(glfwVidMode);
+        int blueBits = (Integer) getBlueBits.invoke(glfwVidMode);
+        int rate = (Integer) getFrequency.invoke(glfwVidMode);
+        int bitDepth = redBits + greenBits + blueBits;
+
+        DisplayMode dm = new DisplayMode(width, height);
+        dm.addRefreshRate(rate);
+        dm.addBitDepth(bitDepth);
+        
+        return dm;
+    }
+
+    @Override
+    public boolean isFullScreenSupported() {
+        return true;
+    }
+
+}


### PR DESCRIPTION
Fixes two things.

I installed a fresh system and saw that the gamma correction is on by default, came with some jME upgrade. So unless you have old settings, your videos and graphics are a bit burnt. Too bright. Turn gamma off by default.

The current way of getting display modes is really bugged. Especially on Linux, it is almost impossible to get correct readings. Also with MacOS and LWJGL 3 this poses an actual bug that causes freeze. We now query the display modes primarily from LWJGL (2 & 3 both supported), this should give much better accuracy than the current AWT (used as a fallback only with this PR).