### PR TITLE
Feature/creature conversion

### DIFF
--- a/src/toniarts/openkeeper/game/component/CreatureTortured.java
+++ b/src/toniarts/openkeeper/game/component/CreatureTortured.java
@@ -25,15 +25,17 @@ import com.simsilica.es.EntityComponent;
  */
 public class CreatureTortured implements EntityComponent {
 
-    public double startTime;
+    public double timeTortured;
+    public double tortureCheckTime;
     public double healthCheckTime;
 
     public CreatureTortured() {
         // For serialization
     }
 
-    public CreatureTortured(double startTime, double healthCheckTime) {
-        this.startTime = startTime;
+    public CreatureTortured(double timeTortured, double tortureCheckTime, double healthCheckTime) {
+        this.timeTortured = timeTortured;
+        this.tortureCheckTime = tortureCheckTime;
         this.healthCheckTime = healthCheckTime;
     }
 

--- a/src/toniarts/openkeeper/game/controller/CreaturesController.java
+++ b/src/toniarts/openkeeper/game/controller/CreaturesController.java
@@ -395,7 +395,7 @@ public class CreaturesController implements ICreaturesController {
             }
             if (room.hasObjectControl(AbstractRoomController.ObjectType.TORTUREE)) {
                 room.getObjectControl(AbstractRoomController.ObjectType.TORTUREE).addItem(entityId, location);
-                entityData.setComponent(entityId, new CreatureTortured(gameTimer.getGameTime(), gameTimer.getGameTime()));
+                entityData.setComponent(entityId, new CreatureTortured(0, gameTimer.getGameTime(), gameTimer.getGameTime()));
                 return CreatureState.TORTURED;
             }
         }

--- a/src/toniarts/openkeeper/game/controller/GameController.java
+++ b/src/toniarts/openkeeper/game/controller/GameController.java
@@ -257,7 +257,7 @@ public class GameController implements IGameLogicUpdatable, AutoCloseable, IGame
                 new CreatureExperienceSystem(entityData, kwdFile, gameSettings, gameWorldController.getCreaturesController()),
                 new SlapSystem(entityData, kwdFile, playerControllers.values(), gameSettings),
                 new HealthSystem(entityData, kwdFile, positionSystem, gameSettings, gameWorldController.getCreaturesController(), this, playerControllers.values(), gameWorldController.getMapController()),
-                new CreatureTorturingSystem(entityData, gameSettings),
+                new CreatureTorturingSystem(entityData, gameWorldController.getCreaturesController(), gameWorldController.getMapController()),
                 new DeathSystem(entityData, gameSettings, positionSystem),
                 new PlayerCreatureSystem(entityData, kwdFile, playerControllers.values()),
                 new PlayerSpellbookSystem(entityData, kwdFile, playerControllers.values()),

--- a/src/toniarts/openkeeper/game/controller/GameWorldController.java
+++ b/src/toniarts/openkeeper/game/controller/GameWorldController.java
@@ -761,7 +761,7 @@ public class GameWorldController implements IGameWorldController, IPlayerActions
 
                     // Set the component, continue the torturing time if such is possible
                     CreatureTortured tortured = entityData.getComponent(entity, CreatureTortured.class);
-                    entityData.setComponent(entity, new CreatureTortured(tortured != null ? tortured.startTime : gameTimer.getGameTime(), gameTimer.getGameTime()));
+                    entityData.setComponent(entity, new CreatureTortured(tortured != null ? tortured.timeTortured : 0.0d, gameTimer.getGameTime(), gameTimer.getGameTime()));
                 }
             }
             tortureOrImprisonment = imprison || torture;

--- a/src/toniarts/openkeeper/game/controller/TrapsController.java
+++ b/src/toniarts/openkeeper/game/controller/TrapsController.java
@@ -37,7 +37,6 @@ import toniarts.openkeeper.tools.convert.map.Thing;
 import toniarts.openkeeper.tools.convert.map.Trap;
 import toniarts.openkeeper.tools.convert.map.Variable;
 import toniarts.openkeeper.utils.WorldUtils;
-import toniarts.openkeeper.view.map.MapViewController;
 
 /**
  * This is a controller that controls all the traps in the world TODO:

--- a/src/toniarts/openkeeper/game/controller/creature/CreatureController.java
+++ b/src/toniarts/openkeeper/game/controller/creature/CreatureController.java
@@ -1310,4 +1310,25 @@ public class CreatureController extends EntityController implements ICreatureCon
         }
     }
 
+    @Override
+    public void convertCreature(short playerId) {
+
+        // Remove our lair from the last player
+        CreatureSleep creatureSleep = entityData.getComponent(entityId, CreatureSleep.class);
+        if (creatureSleep != null && creatureSleep.lairObjectId != null) {
+            entityData.removeEntity(creatureSleep.lairObjectId);
+            entityData.setComponent(entityId, new CreatureSleep(null, creatureSleep.lastSleepTime, creatureSleep.sleepStartTime));
+        }
+
+        // Set new owner
+        entityData.setComponent(entityId, new Owner(playerId, playerId));
+
+        // Remove good player stuff
+        entityData.removeComponent(entityId, Objective.class);
+        entityData.removeComponent(entityId, Party.class);
+
+        // Reset AI
+        getStateMachine().changeState(CreatureState.IDLE);
+    }
+
 }

--- a/src/toniarts/openkeeper/game/controller/creature/CreatureController.java
+++ b/src/toniarts/openkeeper/game/controller/creature/CreatureController.java
@@ -515,7 +515,6 @@ public class CreatureController extends EntityController implements ICreatureCon
         } else {
             attackTargetController = creaturesController.createController(attackTarget.entityId);
         }
-
         return attackTargetController;
     }
 
@@ -526,8 +525,7 @@ public class CreatureController extends EntityController implements ICreatureCon
         return ourPos.equals(theirPos) || navigationService.findPath(ourPos, theirPos, this) != null;
     }
 
-    @Override
-    public void setAttackTarget(EntityId entity) {
+    private void setAttackTarget(EntityId entity) {
         if (entity == null) {
             entityData.removeComponent(entityId, AttackTarget.class);
         } else {

--- a/src/toniarts/openkeeper/game/controller/creature/CreatureController.java
+++ b/src/toniarts/openkeeper/game/controller/creature/CreatureController.java
@@ -1331,7 +1331,6 @@ public class CreatureController extends EntityController implements ICreatureCon
 
         // Remove good player stuff
         entityData.removeComponent(entity, Objective.class);
-        entityData.removeComponent(entity, Party.class);
 
         // Reset AI
         getStateMachine().changeState(CreatureState.IDLE);

--- a/src/toniarts/openkeeper/game/controller/creature/CreatureController.java
+++ b/src/toniarts/openkeeper/game/controller/creature/CreatureController.java
@@ -515,6 +515,7 @@ public class CreatureController extends EntityController implements ICreatureCon
         } else {
             attackTargetController = creaturesController.createController(attackTarget.entityId);
         }
+
         return attackTargetController;
     }
 
@@ -525,7 +526,8 @@ public class CreatureController extends EntityController implements ICreatureCon
         return ourPos.equals(theirPos) || navigationService.findPath(ourPos, theirPos, this) != null;
     }
 
-    private void setAttackTarget(EntityId entity) {
+    @Override
+    public void setAttackTarget(EntityId entity) {
         if (entity == null) {
             entityData.removeComponent(entityId, AttackTarget.class);
         } else {

--- a/src/toniarts/openkeeper/game/controller/creature/CreatureState.java
+++ b/src/toniarts/openkeeper/game/controller/creature/CreatureState.java
@@ -256,8 +256,8 @@ public enum CreatureState implements State<ICreatureController> {
         }
 
         @Override
-            public void exit(ICreatureController entity) {
-                entity.setAttackTarget(null);
+        public void exit(ICreatureController entity) {
+
         }
 
         @Override

--- a/src/toniarts/openkeeper/game/controller/creature/CreatureState.java
+++ b/src/toniarts/openkeeper/game/controller/creature/CreatureState.java
@@ -256,8 +256,8 @@ public enum CreatureState implements State<ICreatureController> {
         }
 
         @Override
-        public void exit(ICreatureController entity) {
-
+            public void exit(ICreatureController entity) {
+                entity.setAttackTarget(null);
         }
 
         @Override

--- a/src/toniarts/openkeeper/game/controller/creature/ICreatureController.java
+++ b/src/toniarts/openkeeper/game/controller/creature/ICreatureController.java
@@ -254,4 +254,11 @@ public interface ICreatureController extends IGameLogicUpdatable, INavigable, IE
      */
     public void setPossession(boolean possessed);
 
+    /**
+     * Converts creature to another player's bidding
+     *
+     * @param playerId the new player ID
+     */
+    public void convertCreature(short playerId);
+
 }

--- a/src/toniarts/openkeeper/game/controller/creature/ICreatureController.java
+++ b/src/toniarts/openkeeper/game/controller/creature/ICreatureController.java
@@ -86,6 +86,8 @@ public interface ICreatureController extends IGameLogicUpdatable, INavigable, IE
 
     public ICreatureController getAttackTarget();
 
+    public void setAttackTarget(EntityId entity);
+
     public boolean isWithinAttackDistance(EntityId attackTarget);
 
     public void stopCreature();

--- a/src/toniarts/openkeeper/game/controller/creature/ICreatureController.java
+++ b/src/toniarts/openkeeper/game/controller/creature/ICreatureController.java
@@ -86,8 +86,6 @@ public interface ICreatureController extends IGameLogicUpdatable, INavigable, IE
 
     public ICreatureController getAttackTarget();
 
-    public void setAttackTarget(EntityId entity);
-
     public boolean isWithinAttackDistance(EntityId attackTarget);
 
     public void stopCreature();

--- a/src/toniarts/openkeeper/game/logic/CreatureTorturingSystem.java
+++ b/src/toniarts/openkeeper/game/logic/CreatureTorturingSystem.java
@@ -21,6 +21,7 @@ import com.simsilica.es.EntityData;
 import com.simsilica.es.EntitySet;
 import toniarts.openkeeper.game.component.CreatureComponent;
 import toniarts.openkeeper.game.component.CreatureTortured;
+import toniarts.openkeeper.game.component.Owner;
 import toniarts.openkeeper.game.component.Position;
 import toniarts.openkeeper.game.controller.ICreaturesController;
 import toniarts.openkeeper.game.map.IMapInformation;
@@ -45,7 +46,7 @@ public class CreatureTorturingSystem implements IGameLogicUpdatable {
         this.mapInformation = mapInformation;
 
         // Have the position also here, since the player may move tortured entities between torture rooms, kinda still tortured but not counting towards death at the time
-        torturedEntities = entityData.getEntities(CreatureTortured.class, CreatureComponent.class, Position.class);
+        torturedEntities = entityData.getEntities(CreatureTortured.class, CreatureComponent.class, Position.class, Owner.class);
     }
 
     @Override
@@ -64,11 +65,15 @@ public class CreatureTorturingSystem implements IGameLogicUpdatable {
             CreatureComponent creatureComponent = entity.get(CreatureComponent.class);
             if (creatureTortured.timeTortured + tpf >= creatureComponent.tortureTimeToConvert) {
 
-                // Convert!
+                Owner owner = entity.get(Owner.class);
                 short playerId = mapInformation.getMapData().getTile(WorldUtils.vectorToPoint(entity.get(Position.class).position)).getOwnerId();
-                entityData.removeComponent(entity.getId(), CreatureTortured.class);
-                creaturesController.createController(entity.getId()).convertCreature(playerId);
-                continue;
+                if (owner.ownerId != playerId) {
+
+                    // Convert!
+                    entityData.removeComponent(entity.getId(), CreatureTortured.class);
+                    creaturesController.createController(entity.getId()).convertCreature(playerId);
+                    continue;
+                }
             }
 
             entity.set(new CreatureTortured(creatureTortured.timeTortured + tpf, gameTime, creatureTortured.healthCheckTime));

--- a/src/toniarts/openkeeper/game/logic/CreatureTorturingSystem.java
+++ b/src/toniarts/openkeeper/game/logic/CreatureTorturingSystem.java
@@ -19,12 +19,12 @@ package toniarts.openkeeper.game.logic;
 import com.simsilica.es.Entity;
 import com.simsilica.es.EntityData;
 import com.simsilica.es.EntitySet;
-import java.util.Map;
 import toniarts.openkeeper.game.component.CreatureComponent;
 import toniarts.openkeeper.game.component.CreatureTortured;
-import toniarts.openkeeper.game.component.Health;
 import toniarts.openkeeper.game.component.Position;
-import toniarts.openkeeper.tools.convert.map.Variable;
+import toniarts.openkeeper.game.controller.ICreaturesController;
+import toniarts.openkeeper.game.map.IMapInformation;
+import toniarts.openkeeper.utils.WorldUtils;
 
 /**
  * Handles creatures torturing. When enough... persuasion has been received...
@@ -35,10 +35,14 @@ import toniarts.openkeeper.tools.convert.map.Variable;
 public class CreatureTorturingSystem implements IGameLogicUpdatable {
 
     private final EntityData entityData;
+    private final ICreaturesController creaturesController;
+    private final IMapInformation mapInformation;
     private final EntitySet torturedEntities;
 
-    public CreatureTorturingSystem(EntityData entityData, Map<Variable.MiscVariable.MiscType, Variable.MiscVariable> gameSettings) {
+    public CreatureTorturingSystem(EntityData entityData, ICreaturesController creaturesController, IMapInformation mapInformation) {
         this.entityData = entityData;
+        this.creaturesController = creaturesController;
+        this.mapInformation = mapInformation;
 
         // Have the position also here, since the player may move tortured entities between torture rooms, kinda still tortured but not counting towards death at the time
         torturedEntities = entityData.getEntities(CreatureTortured.class, CreatureComponent.class, Position.class);
@@ -52,11 +56,22 @@ public class CreatureTorturingSystem implements IGameLogicUpdatable {
 
         // Process ticks
         for (Entity entity : torturedEntities) {
-            Health health = entity.get(Health.class);
+            CreatureTortured creatureTortured = entity.get(CreatureTortured.class);
+            if (creatureTortured.tortureCheckTime >= gameTime) {
+                continue;
+            }
 
-            // TODO: Join the persuating player army!!
+            CreatureComponent creatureComponent = entity.get(CreatureComponent.class);
+            if (creatureTortured.timeTortured + tpf >= creatureComponent.tortureTimeToConvert) {
 
-            // TODO: Mood (to MoodSystem)
+                // Convert!
+                short playerId = mapInformation.getMapData().getTile(WorldUtils.vectorToPoint(entity.get(Position.class).position)).getOwnerId();
+                entityData.removeComponent(entity.getId(), CreatureTortured.class);
+                creaturesController.createController(entity.getId()).convertCreature(playerId);
+                continue;
+            }
+
+            entity.set(new CreatureTortured(creatureTortured.timeTortured + tpf, gameTime, creatureTortured.healthCheckTime));
         }
     }
 

--- a/src/toniarts/openkeeper/game/logic/HealthSystem.java
+++ b/src/toniarts/openkeeper/game/logic/HealthSystem.java
@@ -284,7 +284,7 @@ public class HealthSystem implements IGameLogicUpdatable {
             CreatureTortured tortured = entity.get(CreatureTortured.class);
             if (gameTime - tortured.healthCheckTime >= 1) {
                 int tortureHealthRegeneratePerSecond = levelInfo.getLevelData().getCreature(entity.get(CreatureComponent.class).creatureId).getAttributes().getTortureHpChange();
-                entityData.setComponent(entity.getId(), new CreatureTortured(tortured.startTime, tortured.healthCheckTime + 1));
+                entityData.setComponent(entity.getId(), new CreatureTortured(tortured.timeTortured, tortured.tortureCheckTime, tortured.healthCheckTime + 1));
                 delta += tortureHealthRegeneratePerSecond;
 
                 return delta; // Assume no other states can be

--- a/src/toniarts/openkeeper/game/logic/HealthSystem.java
+++ b/src/toniarts/openkeeper/game/logic/HealthSystem.java
@@ -26,6 +26,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import toniarts.openkeeper.game.component.AttackTarget;
 import toniarts.openkeeper.game.component.ChickenAi;
 import toniarts.openkeeper.game.component.CreatureAi;
 import toniarts.openkeeper.game.component.CreatureComponent;
@@ -241,6 +242,7 @@ public class HealthSystem implements IGameLogicUpdatable {
     }
 
     private void processUnconscious(EntityId entityId, Health health, double gameTime) {
+        entityData.removeComponent(entityId, AttackTarget.class);
         entityData.setComponent(entityId, new Health(0, health.maxHealth));
         entityData.setComponent(entityId, new Unconscious(gameTime));
         //entityData.setComponent(entityId, new CreatureAi(gameTime, CreatureState.UNCONSCIOUS, creatureComponent.creatureId)); // Hmm

--- a/src/toniarts/openkeeper/game/trigger/AbstractThingTriggerControl.java
+++ b/src/toniarts/openkeeper/game/trigger/AbstractThingTriggerControl.java
@@ -34,10 +34,6 @@ public abstract class AbstractThingTriggerControl<T> extends PlayerTriggerContro
 
     protected T instanceControl;
 
-    public AbstractThingTriggerControl() { // empty serialization constructor
-        super();
-    }
-
     public AbstractThingTriggerControl(final IGameController gameController, final ILevelInfo levelInfo, final IGameTimer gameTimer, final IMapController mapController,
             final ICreaturesController creaturesController, final int triggerId, final short playerId,
             final PlayerService playerService) {

--- a/src/toniarts/openkeeper/game/trigger/TriggerControl.java
+++ b/src/toniarts/openkeeper/game/trigger/TriggerControl.java
@@ -51,20 +51,13 @@ public class TriggerControl extends Control {
     private static final short TIME_LIMIT_TIMER_ID = 16;
 
     protected TriggerGenericData trigger;
-    protected TriggerGenericData root;
+    protected final TriggerGenericData root;
 
-    protected ILevelInfo levelInfo;
-    protected IGameTimer gameTimer;
-    protected IGameController gameController;
-    protected IMapController mapController;
-    protected ICreaturesController creaturesController;
-
-    /**
-     * empty serialization constructor
-     */
-    public TriggerControl() {
-        super();
-    }
+    protected final ILevelInfo levelInfo;
+    protected final IGameTimer gameTimer;
+    protected final IGameController gameController;
+    protected final IMapController mapController;
+    protected final ICreaturesController creaturesController;
 
     public TriggerControl(final IGameController gameController, final ILevelInfo levelInfo, final IGameTimer gameTimer, final IMapController mapController,
             final ICreaturesController creaturesController, final int triggerId) {

--- a/src/toniarts/openkeeper/game/trigger/TriggerLoader.java
+++ b/src/toniarts/openkeeper/game/trigger/TriggerLoader.java
@@ -50,33 +50,36 @@ public class TriggerLoader {
             Trigger temp = triggers.get(id);
             TriggerData trigger;
 
-            if (temp instanceof TriggerGeneric) {
-                trigger = new TriggerGenericData(id, temp.getRepeatTimes());
-                ((TriggerGenericData) trigger).setType(((TriggerGeneric) temp).getType());
-                ((TriggerGenericData) trigger).setComparison(((TriggerGeneric) temp).getTargetValueComparison());
+            switch (temp) {
+                case TriggerGeneric triggerGeneric -> {
+                    trigger = new TriggerGenericData(id, temp.getRepeatTimes());
+                    ((TriggerGenericData) trigger).setType(triggerGeneric.getType());
+                    ((TriggerGenericData) trigger).setComparison(triggerGeneric.getTargetValueComparison());
 
-                for (String key : temp.getUserDataKeys()) {
-                    trigger.setUserData(key, temp.getUserData(key));
+                    for (String key : temp.getUserDataKeys()) {
+                        trigger.setUserData(key, temp.getUserData(key));
+                    }
+
+                    parent.attachChild(trigger);
+
+                    if (temp.hasChildren()) {
+                        parse(((TriggerGenericData) trigger), temp.getIdChild());
+                    }
+
                 }
+                case TriggerAction triggerAction -> {
+                    trigger = new TriggerActionData(id);
+                    ((TriggerActionData) trigger).setType(triggerAction.getType());
 
-                parent.attachChild(trigger);
+                    for (String key : temp.getUserDataKeys()) {
+                        trigger.setUserData(key, temp.getUserData(key));
+                    }
 
-                if (temp.hasChildren()) {
-                    parse(((TriggerGenericData) trigger), temp.getIdChild());
+                    parent.attachChild(trigger);
+
                 }
-
-            } else if (temp instanceof TriggerAction) {
-                trigger = new TriggerActionData(id);
-                ((TriggerActionData) trigger).setType(((TriggerAction) temp).getType());
-
-                for (String key : temp.getUserDataKeys()) {
-                    trigger.setUserData(key, temp.getUserData(key));
-                }
-
-                parent.attachChild(trigger);
-
-            } else {
-                throw new RuntimeException("Unexpected class " + temp + "!");
+                default ->
+                    throw new RuntimeException("Unexpected class " + temp + "!");
             }
 
             if (temp.hasNext()) {

--- a/src/toniarts/openkeeper/game/trigger/actionpoint/ActionPointTriggerControl.java
+++ b/src/toniarts/openkeeper/game/trigger/actionpoint/ActionPointTriggerControl.java
@@ -41,12 +41,8 @@ public class ActionPointTriggerControl extends TriggerControl {
 
     private static final Logger logger = System.getLogger(ActionPointTriggerControl.class.getName());
 
-    private ActionPoint ap;
-    private IEntityPositionLookup entityPositionLookup;
-
-    public ActionPointTriggerControl() { // empty serialization constructor
-        super();
-    }
+    private final ActionPoint ap;
+    private final IEntityPositionLookup entityPositionLookup;
 
     public ActionPointTriggerControl(final IGameController gameController, final ILevelInfo levelInfo, final IGameTimer gameTimer,
             final IMapController mapController, final ICreaturesController creaturesController, int triggerId, ActionPoint ap,

--- a/src/toniarts/openkeeper/game/trigger/creature/CreatureTriggerControl.java
+++ b/src/toniarts/openkeeper/game/trigger/creature/CreatureTriggerControl.java
@@ -80,7 +80,7 @@ public class CreatureTriggerControl extends AbstractThingTriggerControl<ICreatur
                 }
                 return false;
             case CREATURE_CONVERTED:
-                return false;
+                return instanceControl.getOwnerId() != getPlayerId();
             case CREATURE_CLAIMED:
                 if (instanceControl != null) {
                     return instanceControl.isClaimed();

--- a/src/toniarts/openkeeper/game/trigger/party/PartyTriggerControl.java
+++ b/src/toniarts/openkeeper/game/trigger/party/PartyTriggerControl.java
@@ -29,11 +29,7 @@ import toniarts.openkeeper.tools.convert.map.TriggerGeneric;
 
 public class PartyTriggerControl extends TriggerControl {
 
-    private IPartyController partyController;
-
-    public PartyTriggerControl() { // empty serialization constructor
-        super();
-    }
+    private final IPartyController partyController;
 
     public PartyTriggerControl(final IGameController gameController, final ILevelInfo levelInfo, final IGameTimer gameTimer,
             final IMapController mapController, final ICreaturesController creaturesController, int triggerId,

--- a/src/toniarts/openkeeper/game/trigger/player/PlayerTriggerControl.java
+++ b/src/toniarts/openkeeper/game/trigger/player/PlayerTriggerControl.java
@@ -48,15 +48,8 @@ public class PlayerTriggerControl extends TriggerControl {
     
     private static final Logger logger = System.getLogger(PlayerTriggerControl.class.getName());
 
-    private short playerId;
-    private PlayerService playerService;
-
-    /**
-     * empty serialization constructor
-     */
-    public PlayerTriggerControl() {
-        super();
-    }
+    private final short playerId;
+    private final PlayerService playerService;
 
     public PlayerTriggerControl(final IGameController gameController, final ILevelInfo levelInfo, final IGameTimer gameTimer, final IMapController mapController,
             final ICreaturesController creaturesController, final int triggerId, final short playerId,
@@ -66,8 +59,8 @@ public class PlayerTriggerControl extends TriggerControl {
         this.playerService = playerService;
     }
 
-    public void setPlayer(short playerId) {
-        this.playerId = playerId;
+    public short getPlayerId() {
+        return playerId;
     }
 
     @Override
@@ -246,7 +239,6 @@ public class PlayerTriggerControl extends TriggerControl {
 
             case GUI_TRANSITION_ENDS:
                 return !playerService.isInTransition();
-//                return playerState.isTransitionEnd();
 
             case GUI_BUTTON_PRESSED:
                 return false;

--- a/src/toniarts/openkeeper/view/control/CreatureFlowerControl.java
+++ b/src/toniarts/openkeeper/view/control/CreatureFlowerControl.java
@@ -225,7 +225,7 @@ public class CreatureFlowerControl extends UnitFlowerControl<Creature> {
         }
 
         // Set new owner
-        if (currentDrawnOwnerId == Player.NEUTRAL_PLAYER_ID && currentDrawnOwnerId != getOwnerId()) {
+        if (currentDrawnOwnerId != getOwnerId()) {
             material.setBoolean("FlashColors", false);
             currentDrawnOwnerId = getOwnerId();
             setFlowerColor(getPlayerColor(currentDrawnOwnerId));


### PR DESCRIPTION
Allows creatures to be converted via torturing. The party thing is still a bit iffy, a converted creature might even be elected as a leader of his party. But in practice this should not happen as the whole party is most likely killed at this point and a new one could have been spawned instead.

Also, while I admire the grudge, a minor tweak to prevent creatures to go seek a revenge after recuperation if the target is still alive.