### PR TITLE
Feature/efficient tasks

### DIFF
--- a/src/toniarts/openkeeper/game/controller/GameController.java
+++ b/src/toniarts/openkeeper/game/controller/GameController.java
@@ -265,7 +265,7 @@ public class GameController implements IGameLogicUpdatable, AutoCloseable, IGame
                 new CreatureSpawnSystem(gameWorldController.getCreaturesController(), playerControllers.values(), gameSettings, this, gameWorldController.getMapController()),
                 new ChickenSpawnSystem(gameWorldController.getObjectsController(), playerControllers.values(), gameSettings, this, gameWorldController.getMapController()),
                 new ManaCalculatorLogic(playerControllers.values(), entityData),
-                new CreatureAiSystem(entityData, gameWorldController.getCreaturesController()),
+                new CreatureAiSystem(entityData, gameWorldController.getCreaturesController(), taskManager),
                 new ChickenAiSystem(entityData, gameWorldController.getObjectsController()),
                 new CreatureViewSystem(entityData),
                 new DoorViewSystem(entityData, positionSystem),

--- a/src/toniarts/openkeeper/game/controller/creature/CreatureController.java
+++ b/src/toniarts/openkeeper/game/controller/creature/CreatureController.java
@@ -30,6 +30,7 @@ import java.lang.System.Logger.Level;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 import toniarts.openkeeper.game.component.Attack;
 import toniarts.openkeeper.game.component.AttackTarget;
 import toniarts.openkeeper.game.component.CreatureAi;
@@ -338,18 +339,20 @@ public class CreatureController extends EntityController implements ICreatureCon
     }
 
     @Override
-    public boolean findWork() {
+    public void findWork(Consumer<Boolean> workResult) {
 
         // See if we have some available work
         if (isWorker()) {
-            return (taskManager.assignTask(this, false));
+            taskManager.addToUnemployedWorkerQueue(this, workResult);
+            return;
         }
 
         short owner = getOwnerId();
         if (owner == Player.NEUTRAL_PLAYER_ID || owner == Player.GOOD_PLAYER_ID) {
 
             // Currently no creature specific jobs offered for neutral or good players
-            return false;
+            workResult.accept(false);
+            return;
         }
 
         // See that is there a prefered job for us
@@ -365,10 +368,11 @@ public class CreatureController extends EntityController implements ICreatureCon
 
         // Choose
         if (!jobs.isEmpty()) {
-            return (taskManager.assignTask(this, chooseOnWeight(jobs).getJobType()));
+            workResult.accept(taskManager.assignTask(this, chooseOnWeight(jobs).getJobType()));
+            return;
         }
 
-        return false;
+        workResult.accept(false);
     }
 
     private static Creature.JobPreference chooseOnWeight(List<Creature.JobPreference> items) {

--- a/src/toniarts/openkeeper/game/controller/creature/ICreatureController.java
+++ b/src/toniarts/openkeeper/game/controller/creature/ICreatureController.java
@@ -19,6 +19,7 @@ package toniarts.openkeeper.game.controller.creature;
 import com.badlogic.gdx.ai.fsm.StateMachine;
 import com.simsilica.es.EntityId;
 import java.awt.Point;
+import java.util.function.Consumer;
 import toniarts.openkeeper.game.controller.entity.IEntityController;
 import toniarts.openkeeper.game.controller.object.IObjectController;
 import toniarts.openkeeper.game.data.ObjectiveType;
@@ -64,7 +65,7 @@ public interface ICreatureController extends IGameLogicUpdatable, INavigable, IE
 
     public boolean goToSleep();
 
-    public boolean findWork();
+    public void findWork(Consumer<Boolean> workResult);
 
     public boolean isWorker();
 

--- a/src/toniarts/openkeeper/game/logic/CreatureAiSystem.java
+++ b/src/toniarts/openkeeper/game/logic/CreatureAiSystem.java
@@ -28,6 +28,7 @@ import java.util.Set;
 import toniarts.openkeeper.game.component.CreatureAi;
 import toniarts.openkeeper.game.controller.ICreaturesController;
 import toniarts.openkeeper.game.controller.creature.ICreatureController;
+import toniarts.openkeeper.game.task.ITaskManager;
 
 /**
  * Handles creature logic updates, the creature AI updates that is. The AI is
@@ -43,9 +44,11 @@ public class CreatureAiSystem implements IGameLogicUpdatable {
     private final SafeArrayList<ICreatureController> creatureControllers;
     private final Map<EntityId, ICreatureController> creatureControllersByEntityId;
     private final ICreaturesController creaturesController;
+    private final ITaskManager taskManager;
 
-    public CreatureAiSystem(EntityData entityData, ICreaturesController creaturesController) {
+    public CreatureAiSystem(EntityData entityData, ICreaturesController creaturesController, ITaskManager taskManager) {
         this.creaturesController = creaturesController;
+        this.taskManager = taskManager;
 
         creatureEntities = entityData.getEntities(CreatureAi.class);
         creatureControllers = new SafeArrayList<>(ICreatureController.class);
@@ -67,6 +70,9 @@ public class CreatureAiSystem implements IGameLogicUpdatable {
         for (ICreatureController creatureController : creatureControllers.getArray()) {
             creatureController.processTick(tpf, gameTime);
         }
+
+        // We have a specialty here, process creature worker queue
+        taskManager.processUnemployedWorkerQueue();
     }
 
     private void processAddedEntities(Set<Entity> entities) {

--- a/src/toniarts/openkeeper/game/task/AbstractTask.java
+++ b/src/toniarts/openkeeper/game/task/AbstractTask.java
@@ -22,7 +22,9 @@ import java.awt.Point;
 import java.lang.System.Logger;
 import java.lang.System.Logger.Level;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import toniarts.openkeeper.game.controller.IMapController;
@@ -171,6 +173,7 @@ public abstract class AbstractTask implements Task {
      * @return task location next to the wanted tile
      */
     protected Vector2f getAccessibleTargetNextToLocation(ICreatureController creature) {
+        List<Point> accessibleTiles = new ArrayList<>();
         for (Point taskPerformLocation : WorldUtils.getSurroundingTiles(mapController.getMapData(), getTaskLocation(), false)) {
             for (Point p : WorldUtils.getSurroundingTiles(mapController.getMapData(), getTaskLocation(), false)) {
                 if (p.equals(getTaskLocation())) {
@@ -181,11 +184,23 @@ public abstract class AbstractTask implements Task {
                     continue;
                 }
 
-                // TODO: intelligent coordinates?
-                Vector2f target = new Vector2f(p.x, p.y);
-                if (isReachable(creature, target)) {
-                    return target;
-                }
+                accessibleTiles.add(p);
+            }
+        }
+
+        if (accessibleTiles.isEmpty()) {
+            return null;
+        }
+
+        // Sort by manhattan distance to the creature and get the first reachable one
+        Point startingPoint = WorldUtils.vectorToPoint(creature.getPosition());
+        accessibleTiles.sort((o1, o2) -> {
+            return Integer.compare(WorldUtils.calculateDistance(startingPoint, o1), WorldUtils.calculateDistance(startingPoint, o2));
+        });
+        for (Point p : accessibleTiles) {
+            Vector2f target = new Vector2f(p.x, p.y);
+            if (isReachable(creature, target)) {
+                return target;
             }
         }
 

--- a/src/toniarts/openkeeper/game/task/AbstractTask.java
+++ b/src/toniarts/openkeeper/game/task/AbstractTask.java
@@ -111,8 +111,13 @@ public abstract class AbstractTask implements Task {
     }
 
     @Override
+    public boolean isFull() {
+        return getAssigneeCount() >= getMaxAllowedNumberOfAsignees();
+    }
+
+    @Override
     public boolean canAssign(ICreatureController creature) {
-        return (assignees.size() < getMaxAllowedNumberOfAsignees() && isValid(creature) && isReachable(creature));
+        return (!isFull() && isValid(creature) && isReachable(creature));
     }
 
     @Override

--- a/src/toniarts/openkeeper/game/task/ITaskManager.java
+++ b/src/toniarts/openkeeper/game/task/ITaskManager.java
@@ -17,6 +17,7 @@
 package toniarts.openkeeper.game.task;
 
 import com.simsilica.es.EntityId;
+import java.util.function.Consumer;
 import toniarts.openkeeper.game.controller.creature.ICreatureController;
 import toniarts.openkeeper.game.controller.room.AbstractRoomController;
 import toniarts.openkeeper.tools.convert.map.Creature;
@@ -108,5 +109,19 @@ public interface ITaskManager {
      * @return true if the task was assigned
      */
     boolean assignEatTask(ICreatureController creature);
+
+    /**
+     * Adds a creature to unemployment queue. You need to separately process the
+     * queue
+     *
+     * @param creature the unemployed creature
+     * @param workResult result callback
+     */
+    void addToUnemployedWorkerQueue(ICreatureController creature, Consumer<Boolean> workResult);
+
+    /**
+     * Processes the unemployed workers
+     */
+    void processUnemployedWorkerQueue();
 
 }

--- a/src/toniarts/openkeeper/game/task/ITaskManager.java
+++ b/src/toniarts/openkeeper/game/task/ITaskManager.java
@@ -67,16 +67,6 @@ public interface ITaskManager {
     boolean assignSleepTask(ICreatureController creature);
 
     /**
-     * Assign a task to a creature
-     *
-     * @param creature the creature to assign a task to
-     * @param byDistance whether we should assign the closest task (i.e. if a
-     * player drops the creature somewhere)
-     * @return true if a task was assigned
-     */
-    boolean assignTask(ICreatureController creature, boolean byDistance);
-
-    /**
      * Assigns a creature to given task type
      *
      * @param creature the creature asking for the task

--- a/src/toniarts/openkeeper/game/task/Task.java
+++ b/src/toniarts/openkeeper/game/task/Task.java
@@ -78,6 +78,13 @@ public interface Task {
     int getMaxAllowedNumberOfAsignees();
 
     /**
+     * Is the task assignee count already full
+     *
+     * @return {@code true} if additional workers can't be assigned anymore
+     */
+    boolean isFull();
+
+    /**
      * Task priority, added to distance when evaluating tasks to give out. The
      * bigger the number, the less urgent the task is
      *

--- a/src/toniarts/openkeeper/game/task/TaskManager.java
+++ b/src/toniarts/openkeeper/game/task/TaskManager.java
@@ -17,6 +17,7 @@
 package toniarts.openkeeper.game.task;
 
 import com.badlogic.gdx.ai.pfa.GraphPath;
+import com.jme3.math.Vector2f;
 import com.simsilica.es.Entity;
 import com.simsilica.es.EntityData;
 import com.simsilica.es.EntityId;
@@ -814,7 +815,14 @@ public class TaskManager implements ITaskManager, IGameLogicUpdatable {
 
             // Give points by distance and priority, no need to know can we do the task as this point as it might be a heavy check
             for (Task task : taskQueue) {
-                int points = WorldUtils.calculateDistance(currentLocation, task.getTaskLocation()) + task.getPriority();
+                Vector2f target = task.getTarget(creature);
+                if (target == null) {
+
+                    // Can't reach
+                    continue;
+                }
+
+                int points = WorldUtils.calculateDistance(currentLocation, WorldUtils.vectorToPoint(target)) + task.getPriority();
                 priorizedTasks.add(new TaskWorkerPriority(task, creature, points, workResult));
             }
         }

--- a/src/toniarts/openkeeper/game/task/TaskManager.java
+++ b/src/toniarts/openkeeper/game/task/TaskManager.java
@@ -507,47 +507,6 @@ public class TaskManager implements ITaskManager, IGameLogicUpdatable {
         }
     }
 
-    @Override
-    public boolean assignTask(ICreatureController creature, boolean byDistance) {
-
-        Set<Task> taskQueue = taskQueues.get(creature.getOwnerId());
-        if (taskQueue == null) {
-            return false;
-//            throw new IllegalArgumentException("This task manager instance is not for the given player!");
-        }
-
-        // Sort by distance & priority
-        final Point currentLocation = creature.getCreatureCoordinates();
-        List<Task> prioritisedTaskQueue = new ArrayList<>(taskQueue);
-        Collections.sort(prioritisedTaskQueue, (Task t, Task t1) -> {
-            int result = Integer.compare(t.getAssigneeCount(), t1.getAssigneeCount());
-            if (result == 0) {
-                result = Integer.compare(
-                        WorldUtils.calculateDistance(currentLocation, t.getTaskLocation()) + t.getPriority(),
-                        WorldUtils.calculateDistance(currentLocation, t1.getTaskLocation()) + t1.getPriority()
-                );
-
-                if (result == 0) {
-                    // If the same, compare by date added
-                    return t.getTaskCreated().compareTo(t1.getTaskCreated());
-                }
-            }
-            return result;
-        });
-
-        // Take the first available task from the sorted queue
-        for (Task task : prioritisedTaskQueue) {
-            if (task.canAssign(creature)) {
-
-                // Assign to first task
-                task.assign(creature, true);
-                return true;
-            }
-        }
-
-        return false;
-    }
-
     public void addTask(short playerId, Task task) {
         Set<Task> tasks = taskQueues.get(playerId);
         if (!tasks.contains(task)) {

--- a/src/toniarts/openkeeper/game/task/TaskManager.java
+++ b/src/toniarts/openkeeper/game/task/TaskManager.java
@@ -831,7 +831,7 @@ public class TaskManager implements ITaskManager, IGameLogicUpdatable {
         while (!unemployedWorkers.isEmpty() && !priorizedTasks.isEmpty()) {
 
             // With each iteration we sort to fill the jobs as even as possible (assignee count changes)
-            Collections.sort(priorizedTasks);
+            Collections.sort(priorizedTasks, (o1, o2) -> sortByTaskStatusAndDistance(o1, o2));
 
             Iterator<TaskWorkerPriority> iter = priorizedTasks.iterator();
             while (iter.hasNext()) {
@@ -862,26 +862,25 @@ public class TaskManager implements ITaskManager, IGameLogicUpdatable {
         });
     }
 
-    private static record TaskWorkerPriority(Task task, ICreatureController creature, int points, Consumer<Boolean> workResult) implements Comparable<TaskWorkerPriority> {
+    private int sortByTaskStatusAndDistance(TaskWorkerPriority o1, TaskWorkerPriority o2) {
 
-        @Override
-        public int compareTo(TaskWorkerPriority taskWorkerPriority) {
-
-            // Fill in jobs that have no workers first
-            int result = Integer.compare(task.getAssigneeCount(), taskWorkerPriority.task.getAssigneeCount());
-            if (result != 0) {
-                return result;
-            }
-
-            // Closest creature gets the job
-            result = Integer.compare(points, taskWorkerPriority.points);
-            if (result != 0) {
-                return result;
-            }
-
-            // If the same, compare by date added
-            return task.getTaskCreated().compareTo(taskWorkerPriority.task.getTaskCreated());
+        // Fill in jobs that have no workers first
+        int result = Integer.compare(o1.task.getAssigneeCount(), o2.task.getAssigneeCount());
+        if (result != 0) {
+            return result;
         }
+
+        // Closest creature gets the job
+        result = Integer.compare(o1.points, o2.points);
+        if (result != 0) {
+            return result;
+        }
+
+        // If the same, compare by date added
+        return o1.task.getTaskCreated().compareTo(o2.task.getTaskCreated());
+    }
+
+    private static record TaskWorkerPriority(Task task, ICreatureController creature, int points, Consumer<Boolean> workResult) {
 
     }
 

--- a/src/toniarts/openkeeper/game/task/objective/ObjectiveTaskDecorator.java
+++ b/src/toniarts/openkeeper/game/task/objective/ObjectiveTaskDecorator.java
@@ -150,4 +150,9 @@ public class ObjectiveTaskDecorator implements ObjectiveTask {
         return taskId;
     }
 
+    @Override
+    public boolean isFull() {
+        return task.isFull();
+    }
+
 }

--- a/src/toniarts/openkeeper/view/map/construction/RoomConstructor.java
+++ b/src/toniarts/openkeeper/view/map/construction/RoomConstructor.java
@@ -13,10 +13,9 @@ import com.jme3.scene.BatchNode;
 import com.jme3.scene.Node;
 import com.jme3.scene.Spatial;
 import java.awt.Point;
-import toniarts.openkeeper.utils.AssetUtils;
-import toniarts.openkeeper.view.map.MapViewController;
 import toniarts.openkeeper.common.RoomInstance;
 import toniarts.openkeeper.tools.convert.map.ArtResource;
+import toniarts.openkeeper.utils.AssetUtils;
 import toniarts.openkeeper.utils.WorldUtils;
 import toniarts.openkeeper.view.map.WallSection;
 


### PR DESCRIPTION
Alright, this brings in following improvements:

- Tasks that have multiple access locations (such as dig a tile), try to get the closest location to the worker. However, this is an approximation rather than exact value
- Workers that are seeking work at a same tick are now evaluated as a group, prioritizing filling tasks with no workers and the distance to the task

Previously having 80 imps brought a dungeon to stand still, workers from the far reaches of the realm were summoned to fulfill a duty even if there was a better candidate nearby. Now it is very likely, especially when there is a continuous source of work, that the same imp will continue in the same construction (i.e. dig the next tile after the first one). Now the dungeon is much more efficient. It is not perfect, but definitely an improvement.

What it comes to the design.. I went with a little quirky design. There is now a callback for job availability. CreatureAI system takes care to handle the job queue after each creature AI is processed. This means in practice that all the AI related functions are still executed in the same system. Also since everything happens inside a tick, there is no danger with needing to serialize these callbacks. It poses no risk in implementing other systems. Surely it is not as isolated and simple now as there are things to remember but I think it is ok.

The alternative design would have been a state where a creature is waiting for work and that is then pooled on the next tick. You'd miss a tick like that.