### PR TITLE
Fix for wide screen in main menu

### DIFF
--- a/src/main/java/toniarts/openkeeper/view/map/construction/HeroGateFrontEndConstructor.java
+++ b/src/main/java/toniarts/openkeeper/view/map/construction/HeroGateFrontEndConstructor.java
@@ -121,6 +121,13 @@ public final class HeroGateFrontEndConstructor extends RoomConstructor {
                     root.attachChild(map);
 
                     break;
+                case 13:
+                case 15:
+                    // fix for widescreen, copy the current tile und move it 1 tile behind
+                    final Spatial fixtile = tile.clone();
+                    fixtile.move(0, 0,  1);
+                    root.attachChild(fixtile);
+                    break;
             }
 
             root.attachChild(tile);


### PR DESCRIPTION
Since the original main menu has a fixed resolution and aspect ratio, its not noticable that the actual room is unfinished (has no model or texture in the back).
While our current implementation is exactly like the original, i still would implement a little fix so the "black hole" isn't noticble while (De-)Briefing or looking at the Extras-Menu.

It basically just clones the original asset and moves it back one tile. 
Since the asset was made to repeat, it's looks quite decent.
The frontend-Menu is anyway just used in the frontend, it should be okay having a "hack" like this.