### PR TITLE
511: Prevent picking up loose gold from unclaimed land

### DIFF
--- a/src/main/java/toniarts/openkeeper/game/controller/EntityPickupValidator.java
+++ b/src/main/java/toniarts/openkeeper/game/controller/EntityPickupValidator.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2014-2026 OpenKeeper
+ *
+ * OpenKeeper is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * OpenKeeper is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenKeeper.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package toniarts.openkeeper.game.controller;
+
+import toniarts.openkeeper.game.component.ObjectComponent;
+import toniarts.openkeeper.game.component.Position;
+import toniarts.openkeeper.game.map.IMapDataInformation;
+import toniarts.openkeeper.game.map.IMapTileInformation;
+import toniarts.openkeeper.utils.WorldUtils;
+
+/**
+ * Pickup rules that are shared by the authoritative game controller and the
+ * client view.
+ *
+ * @author OpenKeeper team
+ */
+public final class EntityPickupValidator {
+
+    private EntityPickupValidator() {
+    }
+
+    /**
+     * Checks object-specific restrictions for the entity's current location.
+     * Loose gold follows the Dungeon Keeper II own-land rule. Other entity
+     * types do not currently have a location restriction.
+     *
+     * @param object object metadata, or {@code null} for a non-object entity
+     * @param position entity position
+     * @param playerId player attempting the pickup
+     * @param mapData current map data
+     * @return {@code true} when the location permits pickup
+     */
+    public static boolean isValidLocation(ObjectComponent object, Position position, short playerId,
+            IMapDataInformation<? extends IMapTileInformation> mapData) {
+        if (object == null || object.objectId != ObjectsController.OBJECT_GOLD_ID) {
+            return true;
+        }
+        if (position == null || mapData == null) {
+            return false;
+        }
+
+        IMapTileInformation tile = mapData.getTile(WorldUtils.vectorToPoint(position.position));
+        return tile != null && tile.getOwnerId() == playerId;
+    }
+}

--- a/src/main/java/toniarts/openkeeper/game/controller/GameWorldController.java
+++ b/src/main/java/toniarts/openkeeper/game/controller/GameWorldController.java
@@ -636,7 +636,7 @@ public final class GameWorldController implements IGameWorldController, IPlayerA
         }
     }
 
-    private static boolean canPickUpEntity(EntityId entityId, short playerId, EntityData entityData) {
+    private boolean canPickUpEntity(EntityId entityId, short playerId, EntityData entityData) {
         // TODO: Somewhere common shared static, can share the rules with the UI client
 
         // Check if picked up already
@@ -656,8 +656,15 @@ public final class GameWorldController implements IGameWorldController, IPlayerA
             return false;
         }
 
-        // TODO: Was it so that it can be only picked up from own land?
-        return interaction.pickUppable && !isEntityIncapacitated(entityId, entityData);
+        if (!interaction.pickUppable || isEntityIncapacitated(entityId, entityData)) {
+            return false;
+        }
+
+        return EntityPickupValidator.isValidLocation(
+                entityData.getComponent(entityId, ObjectComponent.class),
+                entityData.getComponent(entityId, Position.class),
+                playerId,
+                mapController.getMapData());
     }
 
     @Override

--- a/src/main/java/toniarts/openkeeper/game/state/GameClientState.java
+++ b/src/main/java/toniarts/openkeeper/game/state/GameClientState.java
@@ -345,7 +345,7 @@ public final class GameClientState extends AbstractPauseAwareState {
                 };
                 mapInformation = playerMapViewState.getMapInformation();
                 textParser = new TextParserService(mapInformation, playerMapViewState.getRoomsInformation());
-                playerModelViewState = new PlayerEntityViewState(kwdFile, app.getAssetManager(), gameClientService.getEntityData(), playerId, textParser, app.getRootNode());
+                playerModelViewState = new PlayerEntityViewState(kwdFile, app.getAssetManager(), gameClientService.getEntityData(), playerId, textParser, app.getRootNode(), mapInformation.getMapData());
 
                 // Attach the states
                 stateManager.attach(playerState);

--- a/src/main/java/toniarts/openkeeper/view/PlayerEntityViewState.java
+++ b/src/main/java/toniarts/openkeeper/view/PlayerEntityViewState.java
@@ -35,6 +35,8 @@ import toniarts.openkeeper.game.component.DoorViewState;
 import toniarts.openkeeper.game.component.ObjectViewState;
 import toniarts.openkeeper.game.component.Position;
 import toniarts.openkeeper.game.component.TrapViewState;
+import toniarts.openkeeper.game.map.IMapDataInformation;
+import toniarts.openkeeper.game.map.IMapTileInformation;
 import toniarts.openkeeper.tools.convert.map.Creature;
 import toniarts.openkeeper.tools.convert.map.Door;
 import toniarts.openkeeper.tools.convert.map.KwdFile;
@@ -71,6 +73,7 @@ public class PlayerEntityViewState extends AbstractAppState {
     private final EntityData entityData;
     private final short playerId;
     private final Node rootNode;
+    private final IMapDataInformation<? extends IMapTileInformation> mapData;
 
     private final TextParser textParser;
     private final Node root;
@@ -92,6 +95,11 @@ public class PlayerEntityViewState extends AbstractAppState {
     private final Map<EntityId, IEntityViewControl> entityViewControls = new HashMap<>();
 
     public PlayerEntityViewState(KwdFile kwdFile, AssetManager assetManager, EntityData entityData, short playerId, TextParser textParser, Node rootNode) {
+        this(kwdFile, assetManager, entityData, playerId, textParser, rootNode, null);
+    }
+
+    public PlayerEntityViewState(KwdFile kwdFile, AssetManager assetManager, EntityData entityData, short playerId,
+            TextParser textParser, Node rootNode, IMapDataInformation<? extends IMapTileInformation> mapData) {
         super(Short.toString(playerId));
         this.kwdFile = kwdFile;
         this.assetManager = assetManager;
@@ -99,6 +107,7 @@ public class PlayerEntityViewState extends AbstractAppState {
         this.playerId = playerId;
         this.textParser = textParser;
         this.rootNode = rootNode;
+        this.mapData = mapData;
 
         // Init the loaders
         objectLoader = new ObjectLoader(kwdFile);
@@ -192,7 +201,7 @@ public class PlayerEntityViewState extends AbstractAppState {
         if (objectViewState != null) {
             result = objectLoader.load(assetManager, objectViewState);
             if (result != null) {
-                EntityViewControl control = new ObjectViewControl(e.getId(), entityData, kwdFile.getObject(objectViewState.objectId), objectViewState, assetManager, textParser != null ? textParser.getObjectTextParser() : null);
+                EntityViewControl control = new ObjectViewControl(e.getId(), entityData, kwdFile.getObject(objectViewState.objectId), objectViewState, assetManager, textParser != null ? textParser.getObjectTextParser() : null, mapData);
                 result.addControl(control);
 
                 result.setCullHint(objectViewState.visible ? Spatial.CullHint.Inherit : Spatial.CullHint.Always);

--- a/src/main/java/toniarts/openkeeper/view/PlayerInteractionState.java
+++ b/src/main/java/toniarts/openkeeper/view/PlayerInteractionState.java
@@ -419,7 +419,9 @@ public abstract class PlayerInteractionState extends AbstractPauseAwareState {
             tooltip.setText(sb.toString());
         }
 
-        return (interactiveControl != null);
+        return interactiveControl != null
+                && (interactiveControl.isPickable(player.getPlayerId())
+                || interactiveControl.isInteractable(player.getPlayerId()));
     }
 
     private String getRoomTooltip(IMapTileInformation tile, Terrain terrain) {

--- a/src/main/java/toniarts/openkeeper/view/control/ObjectViewControl.java
+++ b/src/main/java/toniarts/openkeeper/view/control/ObjectViewControl.java
@@ -18,10 +18,17 @@ package toniarts.openkeeper.view.control;
 
 import com.jme3.asset.AssetManager;
 import com.jme3.scene.Spatial;
+import com.simsilica.es.EntityComponent;
 import com.simsilica.es.EntityData;
 import com.simsilica.es.EntityId;
+import java.util.Collection;
 import java.util.Objects;
+import toniarts.openkeeper.game.component.ObjectComponent;
 import toniarts.openkeeper.game.component.ObjectViewState;
+import toniarts.openkeeper.game.component.Position;
+import toniarts.openkeeper.game.controller.EntityPickupValidator;
+import toniarts.openkeeper.game.map.IMapDataInformation;
+import toniarts.openkeeper.game.map.IMapTileInformation;
 import toniarts.openkeeper.gui.CursorFactory;
 import toniarts.openkeeper.tools.convert.map.ArtResource;
 import toniarts.openkeeper.tools.convert.map.GameObject;
@@ -37,10 +44,36 @@ import toniarts.openkeeper.view.text.EntityTextParser;
 public final class ObjectViewControl extends EntityViewControl<GameObject, ObjectViewState> {
 
     private boolean initialized = false;
+    private final IMapDataInformation<? extends IMapTileInformation> mapData;
 
     public ObjectViewControl(EntityId entityId, EntityData entityData, GameObject data, ObjectViewState state,
             AssetManager assetManager, EntityTextParser<GameObject> textParser) {
+        this(entityId, entityData, data, state, assetManager, textParser, null);
+    }
+
+    public ObjectViewControl(EntityId entityId, EntityData entityData, GameObject data, ObjectViewState state,
+            AssetManager assetManager, EntityTextParser<GameObject> textParser,
+            IMapDataInformation<? extends IMapTileInformation> mapData) {
         super(entityId, entityData, data, state, assetManager, textParser);
+        this.mapData = mapData;
+    }
+
+    @Override
+    protected Collection<Class<? extends EntityComponent>> getWatchedComponents() {
+        Collection<Class<? extends EntityComponent>> components = super.getWatchedComponents();
+        components.add(ObjectComponent.class);
+        components.add(Position.class);
+        return components;
+    }
+
+    @Override
+    public boolean isPickable(short playerId) {
+        return super.isPickable(playerId)
+                && (mapData == null || EntityPickupValidator.isValidLocation(
+                        getEntity().get(ObjectComponent.class),
+                        getEntity().get(Position.class),
+                        playerId,
+                        mapData));
     }
 
     @Override

--- a/src/main/java/toniarts/openkeeper/view/control/ObjectViewControl.java
+++ b/src/main/java/toniarts/openkeeper/view/control/ObjectViewControl.java
@@ -77,6 +77,16 @@ public final class ObjectViewControl extends EntityViewControl<GameObject, Objec
     }
 
     @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return super.equals(obj);
+    }
+
+    @Override
     public void setSpatial(Spatial spatial) {
         super.setSpatial(spatial);
 

--- a/src/main/java/toniarts/openkeeper/view/control/ObjectViewControl.java
+++ b/src/main/java/toniarts/openkeeper/view/control/ObjectViewControl.java
@@ -78,12 +78,21 @@ public final class ObjectViewControl extends EntityViewControl<GameObject, Objec
 
     @Override
     public int hashCode() {
-        return super.hashCode();
+        int hash = 7;
+        hash = 41 * hash + Objects.hashCode(getEntityId());
+        return hash;
     }
 
     @Override
     public boolean equals(Object obj) {
-        return super.equals(obj);
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        ObjectViewControl other = (ObjectViewControl) obj;
+        return Objects.equals(getEntityId(), other.getEntityId());
     }
 
     @Override


### PR DESCRIPTION
Fixes #511

## Summary
- require loose gold to be on land owned by the requesting player before it can be picked up
- enforce the rule authoritatively on the server and mirror it in the client view
- keep the default animated hand over unpickable loose gold, matching Dungeon Keeper II
- leave creature and other object pickup behavior unchanged

## Verification
- compared neutral-land loose-gold pickup and cursor behavior with Dungeon Keeper II Level 1
- verified loose gold is unavailable on neutral land and becomes pickable after claiming the tile
- ran `./gradlew test` successfully