### PR TITLE
Debriefing fix

### DIFF
--- a/assets/Interface/MainMenu.xml
+++ b/assets/Interface/MainMenu.xml
@@ -232,7 +232,7 @@
 
             <panel height="26px" />
             <!--Main objectives-->
-            <panel childLayout="horizontal" width="100%" align="center" valign="center">
+            <panel id="main_objective" childLayout="horizontal" width="100%" align="center" valign="center">
                 <panel childLayout="center" width="160px" align="center" valign="center">
                     <image align="center" valign="top" id="dMainObjectiveImage" width="144px" />
                 </panel>
@@ -242,9 +242,9 @@
                     </panel>
                     <panel childLayout="horizontal" backgroundColor="#0008" marginTop="4px">
                         <panel childLayout="vertical" width="70%" paddingLeft="10px">
-                            <text text="${menu.1641}" align="left" style="menuTextSmall" />
-                            <text text="${menu.1637}" align="left" style="menuTextSmall" />
-                            <text text="${menu.1638}" align="left" style="menuTextSmall" />
+                            <text text="${menu.1641}" id="label_totalEvilRating" align="left" style="menuTextSmall" />
+                            <text text="${menu.1637}" id="label_overallTotalEvilRating" align="left" style="menuTextSmall" />
+                            <text text="${menu.1638}" id="label_specialsFound" align="left" style="menuTextSmall" />
                         </panel>
                         <panel childLayout="vertical" width="*">
                             <control name="label" id="totalEvilRating" text="?" style="menuTextSmall"
@@ -260,7 +260,7 @@
 
             <panel height="10px" />
             <!--Subobjectives-->
-            <panel childLayout="horizontal" width="100%" align="center" valign="center">
+            <panel id="sub_objective" childLayout="horizontal" width="100%" align="center" valign="center">
                 <panel childLayout="center" width="160px" align="center" valign="center">
                     <image align="center" valign="top" id="dSubObjectiveImage" width="144px"/>
                 </panel>
@@ -269,19 +269,19 @@
                         <!-- TODO maybe use Table ? -->
                         <panel childLayout="horizontal" width="100%">
                             <panel childLayout="vertical" width="70%" paddingLeft="10px">
-                                <text text="${menu.1516}" align="left" style="menuTextSmall" />
-                                <text text="${menu.1410}" align="left" style="menuTextSmall" /> <!-- or 987 -->
-                                <text text="${menu.1413}" align="left" style="menuTextSmall" /> <!-- or 988 -->
-                                <text text="${menu.1509}" align="left" style="menuTextSmall" />
-                                <text text="${menu.1510}" align="left" style="menuTextSmall" />
-                                <text text="${menu.1511}" align="left" style="menuTextSmall" />
-                                <text text="${menu.1411}" align="left" style="menuTextSmall" /> <!-- or 994 -->
-                                <text text="${menu.1512}" align="left" style="menuTextSmall" />
-                                <text text="${menu.1513}" align="left" style="menuTextSmall" />
-                                <text text="${menu.1514}" align="left" style="menuTextSmall" />
-                                <text text="${menu.1429}" align="left" style="menuTextSmall" /> <!-- or 1002 -->
-                                <text text="${menu.1515}" align="left" style="menuTextSmall" />
-                                <text text="${menu.1636}" align="left" style="menuTextSmall" />
+                                <text text="${menu.1516}" id="label_levelWon" align="left" style="menuTextSmall" />
+                                <text text="${menu.1410}" id="label_timeTaken" align="left" style="menuTextSmall" /> <!-- or 987 -->
+                                <text text="${menu.1413}" id="label_enemyCreaturesKilled" align="left" style="menuTextSmall" /> <!-- or 988 -->
+                                <text text="${menu.1509}" id="label_heroesDestroyed" align="left" style="menuTextSmall" />
+                                <text text="${menu.1510}" id="label_roomsCaptured" align="left" style="menuTextSmall" />
+                                <text text="${menu.1511}" id="label_landOwned" align="left" style="menuTextSmall" />
+                                <text text="${menu.1411}" id="label_goldMined" align="left" style="menuTextSmall" /> <!-- or 994 -->
+                                <text text="${menu.1512}" id="label_manaStored" align="left" style="menuTextSmall" />
+                                <text text="${menu.1513}" id="label_itemsManufactured" align="left" style="menuTextSmall" />
+                                <text text="${menu.1514}" id="label_creaturesCommanded" align="left" style="menuTextSmall" />
+                                <text text="${menu.1429}" id="label_creaturesConverted" align="left" style="menuTextSmall" /> <!-- or 1002 -->
+                                <text text="${menu.1515}" id="label_creatureTraining" align="left" style="menuTextSmall" />
+                                <text text="${menu.1636}" id="label_attemptsAtLevel" align="left" style="menuTextSmall" />
                             </panel>
                             <panel childLayout="vertical" width="*" paddingRight="30px">
                                 <control name="label" id="levelWon" text="?" style="menuSubTitleText"
@@ -296,9 +296,9 @@
                                          textHAlign="right" textVAlign="center" width="100%" />
                                 <control name="label" id="landOwned" text="?" style="menuSubTitleText"
                                          textHAlign="right" textVAlign="center" width="100%" />
-                                <control name="label" id="GoldMined" text="?" style="menuSubTitleText"
+                                <control name="label" id="goldMined" text="?" style="menuSubTitleText"
                                          textHAlign="right" textVAlign="center" width="100%" />
-                                <control name="label" id="ManaStored" text="?" style="menuSubTitleText"
+                                <control name="label" id="manaStored" text="?" style="menuSubTitleText"
                                          textHAlign="right" textVAlign="center" width="100%" />
                                 <control name="label" id="itemsManufactured" text="?" style="menuSubTitleText"
                                          textHAlign="right" textVAlign="center" width="100%" />
@@ -306,9 +306,9 @@
                                          textHAlign="right" textVAlign="center" width="100%" />
                                 <control name="label" id="creaturesConverted" text="?" style="menuSubTitleText"
                                          textHAlign="right" textVAlign="center" width="100%" />
-                                <control name="label" id="creatureTraning" text="?" style="menuSubTitleText"
+                                <control name="label" id="creatureTraining" text="?" style="menuSubTitleText"
                                          textHAlign="right" textVAlign="center" width="100%" />
-                                <control name="label" id="AttemptsAtLevel" text="?" style="menuSubTitleText"
+                                <control name="label" id="attemptsAtLevel" text="?" style="menuSubTitleText"
                                          textHAlign="right" textVAlign="center" width="100%" />
                             </panel>
                         </panel>

--- a/assets/Interface/MainMenu.xml
+++ b/assets/Interface/MainMenu.xml
@@ -234,7 +234,8 @@
             <!--Main objectives-->
             <panel id="main_objective" childLayout="horizontal" width="100%" align="center" valign="center">
                 <panel childLayout="center" width="160px" align="center" valign="center">
-                    <image align="center" valign="top" id="dMainObjectiveImage" width="144px" />
+                    <image align="center" valign="top" id="dMainObjectiveImage" width="144px" height="112px" />
+                    <panel height="*" />
                 </panel>
                 <panel childLayout="vertical" width="*" align="left" valign="top">
                     <panel childLayout="vertical" backgroundColor="#f508" width="100%" paddingLeft="10px" >
@@ -262,7 +263,8 @@
             <!--Subobjectives-->
             <panel id="sub_objective" childLayout="horizontal" width="100%" align="center" valign="center">
                 <panel childLayout="center" width="160px" align="center" valign="center">
-                    <image align="center" valign="top" id="dSubObjectiveImage" width="144px"/>
+                    <image align="center" valign="top" id="dSubObjectiveImage" width="144px" height="112px"/>
+                    <panel height="*" />
                 </panel>
                 <panel childLayout="overlay" width="*" align="left" valign="top" backgroundColor="#f508">
                     <control name="scrollPanel" horizontal="false" stepSizeY="30">

--- a/src/main/java/toniarts/openkeeper/game/controller/GameController.java
+++ b/src/main/java/toniarts/openkeeper/game/controller/GameController.java
@@ -294,18 +294,12 @@ public final class GameController implements IGameLogicUpdatable, IGameControlle
 
     @Override
     public void endGame(short playerId, boolean win) {
-        throw new UnsupportedOperationException("Not supported yet.");
-    }
 
-    public void setEnd(boolean win) {
-
-        // TODO: this is client stuff, we should only determine here what happens to the game & players
+        // Determine what happens to the game & players
         gameResult = new GameResult();
         gameResult.setData(GameResult.ResultType.LEVEL_WON, win);
-        gameResult.setData(GameResult.ResultType.TIME_TAKEN, getContoller(IGameTimer.class).getGameTime());
+        gameResult.setData(GameResult.ResultType.TIME_TAKEN, gameTimer.getGameTime());
 
-        // Enable the end game state
-//        stateManager.getState(PlayerState.class).endGame(win);
         // Mark the achievement if campaign level
         if (levelObject != null) {
             Main.getUserSettings().increaseLevelAttempts(levelObject);
@@ -318,6 +312,9 @@ public final class GameController implements IGameLogicUpdatable, IGameControlle
                 logger.log(Level.ERROR, "Failed to save the level progress!", ex);
             }
         }
+
+        // Enable the end game state on the player (client)
+        playerService.endGame(win, playerId);
     }
 
     @Override

--- a/src/main/java/toniarts/openkeeper/game/data/GameResult.java
+++ b/src/main/java/toniarts/openkeeper/game/data/GameResult.java
@@ -42,7 +42,7 @@ public final class GameResult {
         ITEMS_MANUFACTURED,
         CREATURES_COMMANDED,
         CREATURES_CONVERTED,
-        CREATURE_TRANING,
+        CREATURE_TRAINING,
         ATTEMPTS_AT_LEVEL,
     };
 

--- a/src/main/java/toniarts/openkeeper/game/data/Settings.java
+++ b/src/main/java/toniarts/openkeeper/game/data/Settings.java
@@ -456,7 +456,7 @@ public final class Settings {
      * @param level the level
      */
     public void increaseLevelAttempts(CampaignLevel level) {
-        setSetting(Setting.LEVEL_ATTEMPTS.toString() + level.getLevel(), getLevelAttempts(level) + 1);
+        setSetting(Setting.LEVEL_ATTEMPTS.toString() + level.getLevel() + level.getVariation(), getLevelAttempts(level) + 1);
     }
 
     /**
@@ -468,7 +468,7 @@ public final class Settings {
     public void setLevelStatus(CampaignLevel level, LevelStatus status) {
         switch (level.getType()) {
             case Level:
-                setSetting(Setting.LEVEL_STATUS.toString() + level.getLevel(), status);
+                setSetting(Setting.LEVEL_STATUS.toString() + level.getLevel() + level.getVariation(), status);
                 break;
             case MPD:
                 setSetting(Setting.MPD_LEVEL_STATUS.toString() + level.getLevel(), status);

--- a/src/main/java/toniarts/openkeeper/game/network/game/GameClientService.java
+++ b/src/main/java/toniarts/openkeeper/game/network/game/GameClientService.java
@@ -335,6 +335,13 @@ public final class GameClientService extends AbstractClientService
         }
 
         @Override
+        public void onGameEnded(boolean win) {
+            for (GameSessionListener l : listeners.getArray()) {
+                l.onGameEnded(win);
+            }
+        }
+
+        @Override
         public void onPlaySpeech(int speechId, boolean showText, boolean introduction, int pathId) {
             for (GameSessionListener l : listeners.getArray()) {
                 l.onPlaySpeech(speechId, showText, introduction, pathId);

--- a/src/main/java/toniarts/openkeeper/game/network/game/GameHostedService.java
+++ b/src/main/java/toniarts/openkeeper/game/network/game/GameHostedService.java
@@ -386,6 +386,16 @@ public final class GameHostedService extends AbstractHostedConnectionService imp
         }
     }
 
+    @Override
+    public void endGame(boolean win, short playerId) {
+        for (Map.Entry<ClientInfo, GameSessionImpl> gameSession : players.entrySet()) {
+            if (gameSession.getKey().getKeeper().getId() == playerId) {
+                gameSession.getValue().onGameEnded(win);
+                break;
+            }
+        }
+    }
+
     private final class ServerMessageListener implements MessageListener<HostedConnection> {
 
         public ServerMessageListener() {
@@ -711,6 +721,11 @@ public final class GameHostedService extends AbstractHostedConnectionService imp
         @Override
         public void setPossession(EntityId target) {
             getCallback().setPossession(target);
+        }
+
+        @Override
+        public void onGameEnded(boolean win) {
+            getCallback().onGameEnded(win);
         }
 
     }

--- a/src/main/java/toniarts/openkeeper/game/state/EndGameState.java
+++ b/src/main/java/toniarts/openkeeper/game/state/EndGameState.java
@@ -98,11 +98,14 @@ public final class EndGameState extends AbstractAppState implements RawInputList
     @Override
     public void onKeyEvent(KeyInputEvent evt) {
         if (evt.isPressed()) {
-            if (evt.getKeyCode() == KeyInput.KEY_SPACE || evt.getKeyCode() == KeyInput.KEY_ESCAPE) {
-
-                // FIXME: Space to debriefing & ESC to continue
+            if (evt.getKeyCode() == KeyInput.KEY_SPACE) {
                 stateManager.detach(this);
                 playerState.quitToDebriefing();
+                // also use left control, since escape quits the whole game currently
+            } else if (evt.getKeyCode() == KeyInput.KEY_ESCAPE || evt.getKeyCode() == KeyInput.KEY_LCONTROL) {
+                playerState.setWideScreen(false);
+                playerState.setGeneralText(2901);
+                cleanup();
             }
         }
     }

--- a/src/main/java/toniarts/openkeeper/game/state/EndGameState.java
+++ b/src/main/java/toniarts/openkeeper/game/state/EndGameState.java
@@ -101,11 +101,11 @@ public final class EndGameState extends AbstractAppState implements RawInputList
             if (evt.getKeyCode() == KeyInput.KEY_SPACE) {
                 stateManager.detach(this);
                 playerState.quitToDebriefing();
-                // also use left control, since escape quits the whole game currently
             } else if (evt.getKeyCode() == KeyInput.KEY_ESCAPE || evt.getKeyCode() == KeyInput.KEY_LCONTROL) {
                 playerState.setWideScreen(false);
                 playerState.setGeneralText(2901);
                 cleanup();
+                playerState.setEnabled(true);
             }
         }
     }

--- a/src/main/java/toniarts/openkeeper/game/state/GameClientState.java
+++ b/src/main/java/toniarts/openkeeper/game/state/GameClientState.java
@@ -478,6 +478,11 @@ public final class GameClientState extends AbstractPauseAwareState {
         }
 
         @Override
+        public void onGameEnded(boolean win) {
+            app.enqueue(() -> playerState.endGame(win));
+        }
+
+        @Override
         public void onPlaySpeech(int speechId, boolean showText, boolean introduction, int pathId) {
 
             // TODO: Refactor these, we don't maybe want this logic here, borderline visuals

--- a/src/main/java/toniarts/openkeeper/game/state/IPlayerScreenController.java
+++ b/src/main/java/toniarts/openkeeper/game/state/IPlayerScreenController.java
@@ -67,6 +67,8 @@ public interface IPlayerScreenController extends ScreenController {
 
     public void quitToMainMenu();
 
+    public void quitToDebriefing();
+
     public void quitToOS();
 
     /**

--- a/src/main/java/toniarts/openkeeper/game/state/MainMenuScreenController.java
+++ b/src/main/java/toniarts/openkeeper/game/state/MainMenuScreenController.java
@@ -1259,7 +1259,7 @@ public final class MainMenuScreenController implements IMainMenuScreenController
         levelTitle.setText(gameLevel.getTitle());
         mainObjective.setText(gameLevel.getMainObjective());
 
-        String objectiveImage = String.format(OBJECTIVE_IMAGE_URL, gameLevel.getName(), 0);
+        String objectiveImage = AssetUtils.getCanonicalAssetKey(String.format(OBJECTIVE_IMAGE_URL, gameLevel.getName(), 0));
         try {
             img = nifty.createImage(objectiveImage, false);
             mainObjectiveImage.getRenderer(ImageRenderer.class).setImage(img);
@@ -1288,7 +1288,7 @@ public final class MainMenuScreenController implements IMainMenuScreenController
             subObjectiveImage.hide();
 
             if (state.selectedLevel instanceof CampaignLevel lvl && lvl.getType().equals(LevelType.Level)) {
-                objectiveImage = String.format(OBJECTIVE_IMAGE_URL, gameLevel.getName(), 1);
+                objectiveImage = AssetUtils.getCanonicalAssetKey(String.format(OBJECTIVE_IMAGE_URL, gameLevel.getName(), 1));
                 try {
                     img = nifty.createImage(objectiveImage, false);
                     subObjectiveImage.getRenderer(ImageRenderer.class).setImage(img);
@@ -1325,7 +1325,7 @@ public final class MainMenuScreenController implements IMainMenuScreenController
         GameLevel gameLevel = level.getGameLevel();
         levelTitle.setText(gameLevel.getTitle());
         boolean campaign = state.isDebriefingCampaign();
-        String objectiveImage = String.format(OBJECTIVE_IMAGE_URL, gameLevel.getName(), 0);
+        String objectiveImage = AssetUtils.getCanonicalAssetKey(String.format(OBJECTIVE_IMAGE_URL, gameLevel.getName(), 0));
         try {
             NiftyImage img = nifty.createImage(objectiveImage, false);
             mainObjectiveImage.getRenderer(ImageRenderer.class).setImage(img);
@@ -1343,7 +1343,7 @@ public final class MainMenuScreenController implements IMainMenuScreenController
 
         subObjectiveImage.hide();
         if (campaign && state.selectedLevel instanceof CampaignLevel lvl && lvl.getType().equals(LevelType.Level)) {
-            objectiveImage = String.format(OBJECTIVE_IMAGE_URL, gameLevel.getName(), 1);
+            objectiveImage = AssetUtils.getCanonicalAssetKey(String.format(OBJECTIVE_IMAGE_URL, gameLevel.getName(), 1));
             try {
                 NiftyImage img = nifty.createImage(objectiveImage, false);
                 subObjectiveImage.getRenderer(ImageRenderer.class).setImage(img);

--- a/src/main/java/toniarts/openkeeper/game/state/MainMenuScreenController.java
+++ b/src/main/java/toniarts/openkeeper/game/state/MainMenuScreenController.java
@@ -520,6 +520,10 @@ public final class MainMenuScreenController implements IMainMenuScreenController
         // Close any possible popups, otherwise they stay on the screen they were opened on...
         closePopup();
 
+        if (nifty.getCurrentScreen() == null) {
+            return;
+        }
+
         switch (nifty.getCurrentScreen().getScreenId()) {
             case "selectCampaignLevel":
                 state.inputManager.removeRawInputListener(state.listener);
@@ -1303,7 +1307,7 @@ public final class MainMenuScreenController implements IMainMenuScreenController
         }
     }
 
-    public void showDebriefing(GameResult result) {
+    public void showDebriefing() {
         Screen deScreen = nifty.getScreen(SCREEN_DEBRIEFING_ID);
 
         Label levelTitle = deScreen.findNiftyControl("dLevelTitle", Label.class);
@@ -1345,7 +1349,7 @@ public final class MainMenuScreenController implements IMainMenuScreenController
             }
         }
 
-        // FIXME: GameResult has no data yet
+        // FIXME: GameResult has no data yet and also get it from the client state directly
         boolean levelWon = true; // result.getData(GameResult.ResultType.LEVEL_WON);
         deScreen.findNiftyControl("levelWon", Label.class).setText(levelWon ? "${menu.21}" : "${menu.22}");
         int timeTaken = 0; //Math.round(result.getData(GameResult.ResultType.TIME_TAKEN));

--- a/src/main/java/toniarts/openkeeper/game/state/MainMenuScreenController.java
+++ b/src/main/java/toniarts/openkeeper/game/state/MainMenuScreenController.java
@@ -362,6 +362,7 @@ public final class MainMenuScreenController implements IMainMenuScreenController
         switch (screen.getScreenId()) {
             case "selectCampaignLevel":
                 state.inputManager.addRawInputListener(state.listener);
+                state.refreshCampaignMap();
                 state.showArrows();
                 break;
 

--- a/src/main/java/toniarts/openkeeper/game/state/MainMenuScreenController.java
+++ b/src/main/java/toniarts/openkeeper/game/state/MainMenuScreenController.java
@@ -1345,9 +1345,10 @@ public final class MainMenuScreenController implements IMainMenuScreenController
             }
         }
 
-        boolean levelWon = result.getData(GameResult.ResultType.LEVEL_WON);
+        // FIXME: GameResult has no data yet
+        boolean levelWon = true; // result.getData(GameResult.ResultType.LEVEL_WON);
         deScreen.findNiftyControl("levelWon", Label.class).setText(levelWon ? "${menu.21}" : "${menu.22}");
-        int timeTaken = Math.round(result.getData(GameResult.ResultType.TIME_TAKEN));
+        int timeTaken = 0; //Math.round(result.getData(GameResult.ResultType.TIME_TAKEN));
         deScreen.findNiftyControl("timeTaken", Label.class).setText(Utils.timeToString(timeTaken));
 
         // Play debriefing narration

--- a/src/main/java/toniarts/openkeeper/game/state/MainMenuScreenController.java
+++ b/src/main/java/toniarts/openkeeper/game/state/MainMenuScreenController.java
@@ -70,6 +70,7 @@ import toniarts.openkeeper.gui.nifty.table.player.PlayerTableRow;
 import toniarts.openkeeper.tools.convert.AssetsConverter;
 import toniarts.openkeeper.tools.convert.map.AI;
 import toniarts.openkeeper.tools.convert.map.GameLevel;
+import toniarts.openkeeper.tools.convert.map.IKwdFile;
 import toniarts.openkeeper.tools.convert.map.IKwdMap;
 import toniarts.openkeeper.tools.modelviewer.SoundsLoader;
 import toniarts.openkeeper.utils.AssetUtils;
@@ -308,8 +309,11 @@ public final class MainMenuScreenController implements IMainMenuScreenController
             goToScreen("myPetDungeonMapSelect");
         } else if (state.selectedLevel instanceof CampaignLevel lvl && lvl.getType().equals(LevelType.MPD)) {
             goToScreen("myPetDungeon");
-        } else {
+        } else if (state.selectedLevel != null) {
             doTransition("254", "selectCampaignLevel", null);
+        } else {
+            // Skirmish / multiplayer debriefing, return to the single player screen
+            doTransition("272", "singlePlayer", "274");
         }
         state.selectedLevel = null;
     }
@@ -536,6 +540,7 @@ public final class MainMenuScreenController implements IMainMenuScreenController
 
             case "debriefing":
                 state.clearLevelDebriefingNarration();
+                state.clearDebriefing();
                 break;
 
             case "skirmishLobby":
@@ -1315,12 +1320,13 @@ public final class MainMenuScreenController implements IMainMenuScreenController
         Element mainObjectiveImage = deScreen.findElementById("dMainObjectiveImage");
         Element subObjectiveImage = deScreen.findElementById("dSubObjectiveImage");
 
-        NiftyImage img = null;
-        GameLevel gameLevel = state.selectedLevel.getKwdMap().getGameLevel();
+        IKwdFile level = state.getDebriefingLevel();
+        GameLevel gameLevel = level.getGameLevel();
         levelTitle.setText(gameLevel.getTitle());
+        boolean campaign = state.isDebriefingCampaign();
         String objectiveImage = String.format(OBJECTIVE_IMAGE_URL, gameLevel.getName(), 0);
         try {
-            img = nifty.createImage(objectiveImage, false);
+            NiftyImage img = nifty.createImage(objectiveImage, false);
             mainObjectiveImage.getRenderer(ImageRenderer.class).setImage(img);
             mainObjectiveImage.setWidth(img.getWidth());
             mainObjectiveImage.setHeight(img.getHeight());
@@ -1335,10 +1341,10 @@ public final class MainMenuScreenController implements IMainMenuScreenController
         Label specialsFound = deScreen.findNiftyControl("specialsFound", Label.class);
 
         subObjectiveImage.hide();
-        if (state.selectedLevel instanceof CampaignLevel lvl && lvl.getType().equals(LevelType.Level)) {
+        if (campaign && state.selectedLevel instanceof CampaignLevel lvl && lvl.getType().equals(LevelType.Level)) {
             objectiveImage = String.format(OBJECTIVE_IMAGE_URL, gameLevel.getName(), 1);
             try {
-                img = nifty.createImage(objectiveImage, false);
+                NiftyImage img = nifty.createImage(objectiveImage, false);
                 subObjectiveImage.getRenderer(ImageRenderer.class).setImage(img);
                 subObjectiveImage.setWidth(img.getWidth());
                 subObjectiveImage.setHeight(img.getHeight());
@@ -1356,9 +1362,8 @@ public final class MainMenuScreenController implements IMainMenuScreenController
         deScreen.findNiftyControl("timeTaken", Label.class).setText(Utils.timeToString(timeTaken));
 
         // Play debriefing narration
-        if (state.selectedLevel instanceof CampaignLevel) {
-            CampaignLevel level = (CampaignLevel) state.selectedLevel;
-            String speech = String.format("Sounds/speech_mentor/speech_mentorHD/lev%02d002.mp2", level.getLevel());
+        if (campaign && state.selectedLevel instanceof CampaignLevel lvl) {
+            String speech = String.format("Sounds/speech_mentor/speech_mentorHD/lev%02d002.mp2", lvl.getLevel());
             AudioNode audioNode = new AudioNode(state.assetManager,
                     AssetUtils.getCanonicalAssetKey(speech),
                     AudioData.DataType.Buffer);

--- a/src/main/java/toniarts/openkeeper/game/state/MainMenuScreenController.java
+++ b/src/main/java/toniarts/openkeeper/game/state/MainMenuScreenController.java
@@ -98,6 +98,8 @@ public final class MainMenuScreenController implements IMainMenuScreenController
 
     private static final String OBJECTIVE_IMAGE_URL = "Textures/Obj_Shots/%s-%d.png";
     private static final String BRIEFING_SPEECH_URL = "Sounds/speech_mentor/speech_mentorHD/lev%02d001.mp2";
+    private static final String DEBRIEFING_WIN_SPEECH_URL = "Sounds/speech_mentor/speech_mentorHD/lev%02d002.mp2";
+    private static final String DEBRIEFING_DEFEAT_SPEECH_URL = "Sounds/speech_mentor/speech_mentorHD/lev%02d003.mp2";
 
     private final MainMenuState state;
     private Nifty nifty;
@@ -1364,7 +1366,7 @@ public final class MainMenuScreenController implements IMainMenuScreenController
 
         // Play debriefing narration
         if (campaign && state.selectedLevel instanceof CampaignLevel lvl) {
-            String speech = String.format("Sounds/speech_mentor/speech_mentorHD/lev%02d002.mp2", lvl.getLevel());
+            String speech = AssetUtils.getCanonicalAssetKey(String.format(levelWon ? DEBRIEFING_WIN_SPEECH_URL : DEBRIEFING_DEFEAT_SPEECH_URL, lvl.getLevel()));
             AudioNode audioNode = new AudioNode(state.assetManager,
                     AssetUtils.getCanonicalAssetKey(speech),
                     AudioData.DataType.Buffer);

--- a/src/main/java/toniarts/openkeeper/game/state/MainMenuState.java
+++ b/src/main/java/toniarts/openkeeper/game/state/MainMenuState.java
@@ -97,6 +97,7 @@ public final class MainMenuState extends AbstractAppState {
     protected GeneralLevel selectedLevel;
     private AudioNode levelBriefing;
     private AudioNode levelDebriefing;
+    private boolean pendingDebriefing;
 
     private IKwdFile frontEndKwd;
     protected final MainMenuInteraction listener;
@@ -252,7 +253,12 @@ public final class MainMenuState extends AbstractAppState {
         app.enqueue(() -> {
 
             // Start screen, do this here since another state may have just changed to empty screen -> have to do it like this, delayed
-            MainMenuState.this.screen.goToScreen(MainMenuScreenController.SCREEN_START_ID);
+            if (pendingDebriefing) {
+                pendingDebriefing = false;
+                MainMenuState.this.screen.showDebriefing();
+            } else {
+                MainMenuState.this.screen.goToScreen(MainMenuScreenController.SCREEN_START_ID);
+            }
             return null;
         });
 
@@ -602,10 +608,12 @@ public final class MainMenuState extends AbstractAppState {
     }
 
     public void doDebriefing(GameResult result) {
+        pendingDebriefing = selectedLevel != null && result != null;
         setEnabled(true);
-        if (selectedLevel != null && result != null) {
-            screen.showDebriefing();
-        } else {
+
+        // The debriefing screen is shown (instead of the start screen) once the
+        // menu has been initialized, see initializeMainMenu()
+        if (!pendingDebriefing) {
             screen.goToScreen(MainMenuScreenController.SCREEN_START_ID);
         }
     }

--- a/src/main/java/toniarts/openkeeper/game/state/MainMenuState.java
+++ b/src/main/java/toniarts/openkeeper/game/state/MainMenuState.java
@@ -101,6 +101,14 @@ public final class MainMenuState extends AbstractAppState {
     private boolean pendingDebriefing;
     private Camera storedCamera;
 
+    /**
+     * The level that was just played and for which we show the debriefing. Unlike {@link #selectedLevel}
+     * (which is only set for campaign/MPD selection) this is set for every game mode, including skirmish and
+     * multiplayer.
+     */
+    private IKwdFile debriefingLevel;
+    private boolean debriefingIsCampaign;
+
     private IKwdFile frontEndKwd;
     protected final MainMenuInteraction listener;
     private Vector3f startLocation;
@@ -626,8 +634,19 @@ public final class MainMenuState extends AbstractAppState {
         levelDebriefing = null;
     }
 
-    public void doDebriefing(GameResult result) {
-        pendingDebriefing = selectedLevel != null && result != null;
+    /**
+     * Show the debriefing screen after a game has ended. The level that was played must be supplied for
+     * non-campaign games, while campaign games can fall back to the selected campaign level.
+     *
+     * @param result the game result
+     * @param level the level that was just played; may be {@code null} to fall back to
+     * {@link #selectedLevel}
+     * @param campaign whether the played level was a campaign level
+     */
+    public void doDebriefing(GameResult result, IKwdFile level, boolean campaign) {
+        debriefingLevel = level != null ? level : (selectedLevel != null ? selectedLevel.getKwdMap().load() : null);
+        debriefingIsCampaign = campaign || selectedLevel instanceof CampaignLevel;
+        pendingDebriefing = result != null;
         setEnabled(true);
 
         // The debriefing screen is shown (instead of the start screen) once the
@@ -635,6 +654,32 @@ public final class MainMenuState extends AbstractAppState {
         if (!pendingDebriefing) {
             screen.goToScreen(MainMenuScreenController.SCREEN_START_ID);
         }
+    }
+
+    /**
+     * Get the level that was just played and for which the debriefing is shown
+     *
+     * @return the played level, or {@code null}
+     */
+    public IKwdFile getDebriefingLevel() {
+        return debriefingLevel;
+    }
+
+    /**
+     * See if the debriefing being shown is for a campaign level
+     *
+     * @return {@code true} if it is a campaign level debriefing
+     */
+    public boolean isDebriefingCampaign() {
+        return debriefingIsCampaign;
+    }
+
+    /**
+     * Clear the level used for the debriefing screen, called when leaving the debriefing
+     */
+    void clearDebriefing() {
+        debriefingLevel = null;
+        debriefingIsCampaign = false;
     }
 
     /**

--- a/src/main/java/toniarts/openkeeper/game/state/MainMenuState.java
+++ b/src/main/java/toniarts/openkeeper/game/state/MainMenuState.java
@@ -27,6 +27,7 @@ import com.jme3.cinematic.events.CinematicEvent;
 import com.jme3.cinematic.events.CinematicEventListener;
 import com.jme3.input.InputManager;
 import com.jme3.math.Vector3f;
+import com.jme3.renderer.Camera;
 import com.jme3.scene.Node;
 import com.simsilica.es.EntityData;
 import com.simsilica.es.EntityId;
@@ -98,6 +99,7 @@ public final class MainMenuState extends AbstractAppState {
     private AudioNode levelBriefing;
     private AudioNode levelDebriefing;
     private boolean pendingDebriefing;
+    private Camera storedCamera;
 
     private IKwdFile frontEndKwd;
     protected final MainMenuInteraction listener;
@@ -193,8 +195,20 @@ public final class MainMenuState extends AbstractAppState {
 
     /**
      * Load the initial main menu camera position
+     *
+     * @param restoreCamera if true, restore the camera position saved when the menu was disabled, otherwise reset to the default start location
      */
-    private void loadCameraStartLocation() {
+    private void loadCameraStartLocation(boolean restoreCamera) {
+        if (restoreCamera && storedCamera != null) {
+            Camera cam = app.getCamera();
+            cam.setFrame(storedCamera.getLocation(), storedCamera.getRotation());
+            cam.setFrustum(storedCamera.getFrustumNear(), storedCamera.getFrustumFar(), storedCamera.getFrustumLeft(),
+                    storedCamera.getFrustumRight(), storedCamera.getFrustumTop(), storedCamera.getFrustumBottom());
+            storedCamera = null;
+            return;
+        }
+        storedCamera = null;
+
         Player player = frontEndKwd.getPlayer(Player.KEEPER1_ID);
         startLocation = WorldUtils.pointToVector3f(player.getStartingCameraX(), player.getStartingCameraY());
         startLocation.addLocal(0, WorldUtils.FLOOR_HEIGHT, 0);
@@ -250,10 +264,12 @@ public final class MainMenuState extends AbstractAppState {
         MainMenuState.this.app.setViewProcessors();
         rootNode.attachChild(menuNode);
 
+        boolean debriefing = pendingDebriefing;
+
         app.enqueue(() -> {
 
             // Start screen, do this here since another state may have just changed to empty screen -> have to do it like this, delayed
-            if (pendingDebriefing) {
+            if (debriefing) {
                 pendingDebriefing = false;
                 MainMenuState.this.screen.showDebriefing();
             } else {
@@ -269,7 +285,7 @@ public final class MainMenuState extends AbstractAppState {
         }
 
         // Set the camera position
-        loadCameraStartLocation();
+        loadCameraStartLocation(debriefing);
     }
 
     @Override
@@ -310,6 +326,9 @@ public final class MainMenuState extends AbstractAppState {
                 initializeMainMenu();
             }
         } else {
+
+            // Save the camera position so that we can restore it (e.g. for the debriefing screen) when re-enabling the menu
+            storedCamera = app.getCamera().clone();
 
             stateManager.getState(MainMenuEntityViewState.class).setEnabled(false);
             if (menuNode != null && rootNode != null) {

--- a/src/main/java/toniarts/openkeeper/game/state/MainMenuState.java
+++ b/src/main/java/toniarts/openkeeper/game/state/MainMenuState.java
@@ -719,5 +719,10 @@ public final class MainMenuState extends AbstractAppState {
             throw new UnsupportedOperationException("Not supported yet.");
         }
 
+        @Override
+        public void endGame(boolean win, short playerId) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
     }
 }

--- a/src/main/java/toniarts/openkeeper/game/state/MainMenuState.java
+++ b/src/main/java/toniarts/openkeeper/game/state/MainMenuState.java
@@ -604,7 +604,7 @@ public final class MainMenuState extends AbstractAppState {
     public void doDebriefing(GameResult result) {
         setEnabled(true);
         if (selectedLevel != null && result != null) {
-            screen.showDebriefing(result);
+            screen.showDebriefing();
         } else {
             screen.goToScreen(MainMenuScreenController.SCREEN_START_ID);
         }

--- a/src/main/java/toniarts/openkeeper/game/state/PlayerScreenController.java
+++ b/src/main/java/toniarts/openkeeper/game/state/PlayerScreenController.java
@@ -153,6 +153,16 @@ public final class PlayerScreenController implements IPlayerScreenController {
         screen = null;
     }
 
+    /**
+     * Re-establish the player state reference after it has been cleaned up, e.g. when the game is
+     * resumed from the end game screen
+     *
+     * @param state the player state
+     */
+    void setState(PlayerState state) {
+        this.state = state;
+    }
+
     @Override
     public void select(String iState, String id) {
         Type type = Type.valueOf(iState.toUpperCase());
@@ -263,7 +273,7 @@ public final class PlayerScreenController implements IPlayerScreenController {
             case MAIN:
                 optionsMenuTitle.setText("${menu.94}");
 
-                items.add(new GameMenu("i-objective", "${menu.537}", "pauseMenu()", optionsColumnOne));
+                     items.add(new GameMenu("i-objective", "${menu.537}", "pauseMenu()", optionsColumnOne));
                 items.add(new GameMenu("i-game", "${menu.97}", "pauseMenu()", optionsColumnOne));
                 items.add(new GameMenu("i-load", "${menu.143}", "pauseMenu()", optionsColumnOne));
                 items.add(new GameMenu("i-save", "${menu.201}", "pauseMenu()", optionsColumnOne));

--- a/src/main/java/toniarts/openkeeper/game/state/PlayerScreenController.java
+++ b/src/main/java/toniarts/openkeeper/game/state/PlayerScreenController.java
@@ -277,8 +277,13 @@ public final class PlayerScreenController implements IPlayerScreenController {
             case QUIT:
                 optionsMenuTitle.setText("${menu.1266}");
 
-                items.add(new GameMenu("i-quit", "${menu.12}", String.format("pauseMenuNavigate(%s,%s,${menu.12},quitToMainMenu())",
-                        PauseMenuState.CONFIRMATION.name(), PauseMenuState.QUIT.name()), optionsColumnOne));
+                if (state.stateManager.getState(EndGameState.class) != null) {
+                    items.add(new GameMenu("i-quit", "${menu.2913}", String.format("pauseMenuNavigate(%s,%s,${menu.2913},quitToDebriefing())",
+                            PauseMenuState.CONFIRMATION.name(), PauseMenuState.QUIT.name()), optionsColumnOne));
+                } else {
+                    items.add(new GameMenu("i-quit", "${menu.12}", String.format("pauseMenuNavigate(%s,%s,${menu.12},quitToMainMenu())",
+                            PauseMenuState.CONFIRMATION.name(), PauseMenuState.QUIT.name()), optionsColumnOne));
+                }
                 items.add(new GameMenu(Utils.isWindows() ? "i-exit_to_windows" : "i-quit", Utils.isWindows() ? "${menu.13}" : "${menu.14}",
                         String.format("pauseMenuNavigate(%s,%s,%s,quitToOS())", PauseMenuState.CONFIRMATION.name(),
                                 PauseMenuState.QUIT.name(), (Utils.isWindows() ? "${menu.13}" : "${menu.14}")), optionsColumnOne));
@@ -371,6 +376,11 @@ public final class PlayerScreenController implements IPlayerScreenController {
     @Override
     public void quitToMainMenu() {
         state.quitToMainMenu();
+    }
+
+    @Override
+    public void quitToDebriefing() {
+        state.quitToDebriefing();
     }
 
     @Override

--- a/src/main/java/toniarts/openkeeper/game/state/PlayerState.java
+++ b/src/main/java/toniarts/openkeeper/game/state/PlayerState.java
@@ -137,6 +137,7 @@ public final class PlayerState extends AbstractAppState implements PlayerListene
 
             // Get the game state
             final GameClientState gameState = stateManager.getState(GameClientState.class);
+            screen.setState(this);
             screen.initHud(gameState.getLevelData().getGameLevel().getTextTableId().getLevelDictFile(), entityData);
 
             // Cursor

--- a/src/main/java/toniarts/openkeeper/game/state/PlayerState.java
+++ b/src/main/java/toniarts/openkeeper/game/state/PlayerState.java
@@ -390,6 +390,7 @@ public final class PlayerState extends AbstractAppState implements PlayerListene
     public void quitToDebriefing() {
         // TODO copy results of game from GameState
         GameResult result = new GameResult();
+        stateManager.getState(GameClientState.class).detach();
         setEnabled(false);
         stateManager.getState(MainMenuState.class).doDebriefing(result);
     }

--- a/src/main/java/toniarts/openkeeper/game/state/PlayerState.java
+++ b/src/main/java/toniarts/openkeeper/game/state/PlayerState.java
@@ -392,7 +392,7 @@ public final class PlayerState extends AbstractAppState implements PlayerListene
         GameResult result = new GameResult();
         stateManager.getState(GameClientState.class).detach();
         stateManager.detach(this);
-        stateManager.getState(MainMenuState.class).doDebriefing(result);
+        stateManager.getState(MainMenuState.class).doDebriefing(result, kwdFile, campaignLevel != null);
     }
 
     public void quitToOS() {

--- a/src/main/java/toniarts/openkeeper/game/state/PlayerState.java
+++ b/src/main/java/toniarts/openkeeper/game/state/PlayerState.java
@@ -391,7 +391,7 @@ public final class PlayerState extends AbstractAppState implements PlayerListene
         // TODO copy results of game from GameState
         GameResult result = new GameResult();
         stateManager.getState(GameClientState.class).detach();
-        setEnabled(false);
+        stateManager.detach(this);
         stateManager.getState(MainMenuState.class).doDebriefing(result);
     }
 

--- a/src/main/java/toniarts/openkeeper/game/state/session/GameSessionListener.java
+++ b/src/main/java/toniarts/openkeeper/game/state/session/GameSessionListener.java
@@ -84,6 +84,14 @@ public interface GameSessionListener extends MapListener, PlayerListener {
     public void onSetWidescreen(boolean enable);
 
     /**
+     * The game has ended for the client
+     *
+     * @param win if true, the client won the game, if not, lost
+     */
+    @Asynchronous
+    public void onGameEnded(boolean win);
+
+    /**
      * The client should play a speech
      *
      * @param speechId     speech ID

--- a/src/main/java/toniarts/openkeeper/game/state/session/LocalGameSession.java
+++ b/src/main/java/toniarts/openkeeper/game/state/session/LocalGameSession.java
@@ -477,4 +477,13 @@ public final class LocalGameSession implements GameSessionServerService, GameSes
         }
     }
 
+    @Override
+    public void endGame(boolean win, short playerId) {
+        if (playerId == PLAYER_ID) {
+            for (GameSessionListener listener : listeners.getArray()) {
+                listener.onGameEnded(win);
+            }
+        }
+    }
+
 }

--- a/src/main/java/toniarts/openkeeper/game/state/session/PlayerService.java
+++ b/src/main/java/toniarts/openkeeper/game/state/session/PlayerService.java
@@ -135,4 +135,12 @@ public interface PlayerService {
      */
     public void setPossession(EntityId target, short playerId);
 
+    /**
+     * End the game for a player
+     *
+     * @param win if true, the player won the game, if not, lost
+     * @param playerId the player whose game ends
+     */
+    public void endGame(boolean win, short playerId);
+
 }

--- a/src/main/java/toniarts/openkeeper/tools/modelviewer/MapLoaderAppState.java
+++ b/src/main/java/toniarts/openkeeper/tools/modelviewer/MapLoaderAppState.java
@@ -182,6 +182,11 @@ public final class MapLoaderAppState extends AbstractAppState {
         public void setPossession(EntityId target, short playerId) {
             throw new UnsupportedOperationException("Not supported yet.");
         }
+
+        @Override
+        public void endGame(boolean win, short playerId) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
     }
 
 }

--- a/src/main/java/toniarts/openkeeper/utils/Utils.java
+++ b/src/main/java/toniarts/openkeeper/utils/Utils.java
@@ -269,17 +269,14 @@ public final class Utils {
             result += days;
         }
         int hours = time / 3600;
-        if (days != 0 || hours != 0) {
+        if (hours != 0) {
             time -= hours * 3600;
-            result += String.format(" %02d", hours);
+            result += String.format(" %02d:", hours);
         }
         int minutes = time / 60;
-        if (days != 0 || hours != 0 || minutes != 0) {
-            time -= minutes * 60;
-            result += String.format(":%02d", minutes);
-        }
+        time -= minutes * 60;
         int seconds = time;
-        result += String.format(":%02d", seconds);
+        result += String.format("%02d:%02d", minutes, seconds);
 
         return result.trim();
     }


### PR DESCRIPTION
Shows the debrief screens for all game types

Features:
* Same camera position as before leaving the main menu into a game level (not just the starting position)
* Re-Enabling EndgameState (wasn't used before)
* Continue playing after Winning a level is possible (option for debriefing in the option menu!)

Also Fixed:
* Several typos
* campaign progress for levels with variation wasn't reset properly
* campaign can't be progressed, because the next level isn't set as playable

Not in scope:
* different debriefing screens for each game type
* Player statistics

Helps #534