### PR TITLE
Improve (De)Briefing screens

### DIFF
--- a/assets/Interface/MainMenu.xml
+++ b/assets/Interface/MainMenu.xml
@@ -32,21 +32,21 @@
         <attributes font="Interface/Fonts/Frontend28.fnt" color="#bbbcbb" />
     </style>
     <style id="menuTitleText">
-        <attributes font="Interface/Fonts/Frontend36.fnt" color="#ccbb11" alpha="0.5" />
+        <attributes font="Interface/Fonts/Frontend36.fnt" color="#ccbb11" />
         <effect>
-            <onActive name="textGlow" color="#ff5f00" alpha="0.2" distance="5" timeType="infinite" neverStopRendering="true" />
+            <onActive name="textGlow" color="#ff5f00" alpha="0.05" distance="7" timeType="infinite" neverStopRendering="true" />
         </effect>
     </style>
 
     <style id="menuSubTitleText">
-        <attributes font="Interface/Fonts/Frontend28.fnt" color="#eeeeee" alpha="0.5" />
+        <attributes font="Interface/Fonts/Frontend28.fnt" color="#eeeeee" />
         <effect>
-            <onActive name="textGlow" color="#ffdd33" alpha="0.2" distance="5" timeType="infinite" neverStopRendering="true" />
+            <onActive name="textGlow" color="#ffdd33" alpha="0.05" distance="7" timeType="infinite" neverStopRendering="true" />
         </effect>
     </style>
 
     <style id="menuHeaderText">
-        <attributes font="Interface/Fonts/Frontend28.fnt" color="#ccbb11" alpha="0.5" />
+        <attributes font="Interface/Fonts/Frontend28.fnt" color="#ccbb11" />
     </style>
 
     <style id="nifty-hiscore-head#text">

--- a/assets/Interface/MainMenu.xml
+++ b/assets/Interface/MainMenu.xml
@@ -12,6 +12,9 @@
     <useControls filename="Interface/MyControls.xml" />
     <useControls filename="Interface/CreditsControl.xml" />
 
+    <!-- custom effects -->
+    <registerEffect name="textGlow" class="toniarts.openkeeper.gui.nifty.effect.TextGlowEffect" />
+
     <style id="text">
         <attributes font="Interface/Fonts/Frontend14.fnt" color="#bbbcbb" />
     </style>
@@ -29,11 +32,21 @@
         <attributes font="Interface/Fonts/Frontend28.fnt" color="#bbbcbb" />
     </style>
     <style id="menuTitleText">
-        <attributes font="Interface/Fonts/Frontend36.fnt" color="#ff5f00" />
+        <attributes font="Interface/Fonts/Frontend36.fnt" color="#ccbb11" alpha="0.5" />
+        <effect>
+            <onActive name="textGlow" color="#ff5f00" alpha="0.2" distance="5" timeType="infinite" neverStopRendering="true" />
+        </effect>
     </style>
 
     <style id="menuSubTitleText">
-        <attributes font="Interface/Fonts/Frontend20.fnt" color="#ffdd33" />
+        <attributes font="Interface/Fonts/Frontend28.fnt" color="#eeeeee" alpha="0.5" />
+        <effect>
+            <onActive name="textGlow" color="#ffdd33" alpha="0.2" distance="5" timeType="infinite" neverStopRendering="true" />
+        </effect>
+    </style>
+
+    <style id="menuHeaderText">
+        <attributes font="Interface/Fonts/Frontend28.fnt" color="#ccbb11" alpha="0.5" />
     </style>
 
     <style id="nifty-hiscore-head#text">
@@ -178,7 +191,7 @@
                 </panel>
                 <panel childLayout="vertical" width="*" align="left" valign="top" height="90%">
                     <panel childLayout="vertical" backgroundColor="#f508" width="100%" >
-                        <text align="left" margin="0,8px" id="mainObjectivesTitle" style="menuSubTitleText" text="${menu.1408}" />
+                        <text align="left" margin="0,8px" id="mainObjectivesTitle" style="menuHeaderText" text="${menu.1408}" />
                     </panel>
                     <panel childLayout="vertical" backgroundColor="#0008" marginTop="4px" height="100%">
                         <control name="label" style="menuTextSmall" margin="0,8px" id="mainObjective"
@@ -195,7 +208,7 @@
                 </panel>
                 <panel childLayout="vertical" width="*" align="left" valign="top" height="90%">
                     <panel childLayout="vertical" width="100%" backgroundColor="#f508" >
-                        <text align="left" margin="0,8px" id="subObjectivesTitle" style="menuSubTitleText" text="${menu.1409}" />
+                        <text align="left" margin="0,8px" id="subObjectivesTitle" style="menuHeaderText" text="${menu.1409}" />
                     </panel>
                     <panel childLayout="vertical" backgroundColor="#0008" marginTop="4px" height="100%">
                         <control name="label" style="menuTextSmall" id="subObjective1"  margin="0,8px"
@@ -239,7 +252,7 @@
                 </panel>
                 <panel childLayout="vertical" width="*" align="left" valign="top" height="90%">
                     <panel childLayout="vertical" backgroundColor="#f508" width="100%" paddingLeft="10px" >
-                        <text text="${menu.2898}" style="menuSubTitleText" align="left" />
+                        <text text="${menu.2898}" style="menuHeaderText" align="left" />
                     </panel>
                     <panel childLayout="horizontal" backgroundColor="#0008" marginTop="4px" height="100%">
                         <panel childLayout="vertical" width="70%" paddingLeft="10px">
@@ -286,31 +299,31 @@
                                 <text text="${menu.1636}" id="label_attemptsAtLevel" align="left" style="menuTextSmall" />
                             </panel>
                             <panel childLayout="vertical" width="*" paddingRight="30px">
-                                <control name="label" id="levelWon" text="?" style="menuSubTitleText"
+                                <control name="label" id="levelWon" text="?" style="menuHeaderText"
                                          textHAlign="right" textVAlign="center" width="100%" />
-                                <control name="label" id="timeTaken" text="?" style="menuSubTitleText"
+                                <control name="label" id="timeTaken" text="?" style="menuHeaderText"
                                          textHAlign="right" textVAlign="center" width="100%" />
-                                <control name="label" id="enemyCreaturesKilled" text="?" style="menuSubTitleText"
+                                <control name="label" id="enemyCreaturesKilled" text="?" style="menuHeaderText"
                                          textHAlign="right" textVAlign="center" width="100%" />
-                                <control name="label" id="heroesDestroyed" text="?" style="menuSubTitleText"
+                                <control name="label" id="heroesDestroyed" text="?" style="menuHeaderText"
                                          textHAlign="right" textVAlign="center" width="100%" />
-                                <control name="label" id="roomsCaptured" text="?" style="menuSubTitleText"
+                                <control name="label" id="roomsCaptured" text="?" style="menuHeaderText"
                                          textHAlign="right" textVAlign="center" width="100%" />
-                                <control name="label" id="landOwned" text="?" style="menuSubTitleText"
+                                <control name="label" id="landOwned" text="?" style="menuHeaderText"
                                          textHAlign="right" textVAlign="center" width="100%" />
-                                <control name="label" id="goldMined" text="?" style="menuSubTitleText"
+                                <control name="label" id="goldMined" text="?" style="menuHeaderText"
                                          textHAlign="right" textVAlign="center" width="100%" />
-                                <control name="label" id="manaStored" text="?" style="menuSubTitleText"
+                                <control name="label" id="manaStored" text="?" style="menuHeaderText"
                                          textHAlign="right" textVAlign="center" width="100%" />
-                                <control name="label" id="itemsManufactured" text="?" style="menuSubTitleText"
+                                <control name="label" id="itemsManufactured" text="?" style="menuHeaderText"
                                          textHAlign="right" textVAlign="center" width="100%" />
-                                <control name="label" id="creaturesCommanded" text="?" style="menuSubTitleText"
+                                <control name="label" id="creaturesCommanded" text="?" style="menuHeaderText"
                                          textHAlign="right" textVAlign="center" width="100%" />
-                                <control name="label" id="creaturesConverted" text="?" style="menuSubTitleText"
+                                <control name="label" id="creaturesConverted" text="?" style="menuHeaderText"
                                          textHAlign="right" textVAlign="center" width="100%" />
-                                <control name="label" id="creatureTraining" text="?" style="menuSubTitleText"
+                                <control name="label" id="creatureTraining" text="?" style="menuHeaderText"
                                          textHAlign="right" textVAlign="center" width="100%" />
-                                <control name="label" id="attemptsAtLevel" text="?" style="menuSubTitleText"
+                                <control name="label" id="attemptsAtLevel" text="?" style="menuHeaderText"
                                          textHAlign="right" textVAlign="center" width="100%" />
                             </panel>
                         </panel>

--- a/assets/Interface/MainMenu.xml
+++ b/assets/Interface/MainMenu.xml
@@ -170,34 +170,34 @@
                 <control name="label" id="levelTitle" style="menuSubTitleText" align="center" />
             </panel>
 
-            <panel height="26px" />
+            <panel height="30px" />
             <!--Main objectives-->
             <panel childLayout="horizontal" id="mainObjectivePanel" width="100%" align="center" valign="center">
-                <panel childLayout="center" width="160px" align="center" valign="center">
-                    <image align="center" valign="top" id="mainObjectiveImage" width="144px" />
+                <panel childLayout="center" width="25%" align="center" valign="center" >
+                    <image align="center" valign="top" id="mainObjectiveImage" filter="true" width="90%" />
                 </panel>
-                <panel childLayout="vertical" width="*" align="left" valign="top">
+                <panel childLayout="vertical" width="*" align="left" valign="top" height="90%">
                     <panel childLayout="vertical" backgroundColor="#f508" width="100%" >
                         <text align="left" margin="0,8px" id="mainObjectivesTitle" style="menuSubTitleText" text="${menu.1408}" />
                     </panel>
-                    <panel childLayout="vertical" backgroundColor="#0008" marginTop="4px">
+                    <panel childLayout="vertical" backgroundColor="#0008" marginTop="4px" height="100%">
                         <control name="label" style="menuTextSmall" margin="0,8px" id="mainObjective"
                                  textHAlign="left" textVAlign="top" wrap="true" />
                     </panel>
                 </panel>
             </panel>
 
-            <panel height="10px" />
+            <panel height="30px" />
             <!--Subobjectives-->
             <panel childLayout="horizontal" id="subObjectivePanel" width="100%" align="center" valign="center">
-                <panel childLayout="center" width="160px" align="center" valign="center">
-                    <image align="center" valign="top" id="subObjectiveImage" width="144px"/>
+                <panel childLayout="center" width="25%" align="center" valign="center">
+                    <image align="center" valign="top" id="subObjectiveImage" filter="true" width="90%" />
                 </panel>
-                <panel childLayout="vertical" width="*" align="left" valign="top">
+                <panel childLayout="vertical" width="*" align="left" valign="top" height="90%">
                     <panel childLayout="vertical" width="100%" backgroundColor="#f508" >
                         <text align="left" margin="0,8px" id="subObjectivesTitle" style="menuSubTitleText" text="${menu.1409}" />
                     </panel>
-                    <panel childLayout="vertical" backgroundColor="#0008" marginTop="4px">
+                    <panel childLayout="vertical" backgroundColor="#0008" marginTop="4px" height="100%">
                         <control name="label" style="menuTextSmall" id="subObjective1"  margin="0,8px"
                                  textHAlign="left" wrap="true" />
                         <control name="label" style="menuTextSmall" id="subObjective2"  margin="0,8px"
@@ -230,18 +230,18 @@
                 <control name="label" id="dLevelTitle" style="menuSubTitleText" align="center" />
             </panel>
 
-            <panel height="26px" />
+            <panel height="30px" />
             <!--Main objectives-->
             <panel id="main_objective" childLayout="horizontal" width="100%" align="center" valign="center">
-                <panel childLayout="center" width="160px" align="center" valign="center">
-                    <image align="center" valign="top" id="dMainObjectiveImage" width="144px" height="112px" />
+                <panel childLayout="center" width="25%" align="center" valign="center">
+                    <image align="center" valign="top" id="dMainObjectiveImage" width="90%" />
                     <panel height="*" />
                 </panel>
-                <panel childLayout="vertical" width="*" align="left" valign="top">
+                <panel childLayout="vertical" width="*" align="left" valign="top" height="90%">
                     <panel childLayout="vertical" backgroundColor="#f508" width="100%" paddingLeft="10px" >
                         <text text="${menu.2898}" style="menuSubTitleText" align="left" />
                     </panel>
-                    <panel childLayout="horizontal" backgroundColor="#0008" marginTop="4px">
+                    <panel childLayout="horizontal" backgroundColor="#0008" marginTop="4px" height="100%">
                         <panel childLayout="vertical" width="70%" paddingLeft="10px">
                             <text text="${menu.1641}" id="label_totalEvilRating" align="left" style="menuTextSmall" />
                             <text text="${menu.1637}" id="label_overallTotalEvilRating" align="left" style="menuTextSmall" />
@@ -259,14 +259,14 @@
                 </panel>
             </panel>
 
-            <panel height="10px" />
+            <panel height="30px" />
             <!--Subobjectives-->
             <panel id="sub_objective" childLayout="horizontal" width="100%" align="center" valign="center">
-                <panel childLayout="center" width="160px" align="center" valign="center">
-                    <image align="center" valign="top" id="dSubObjectiveImage" width="144px" height="112px"/>
+                <panel childLayout="center" width="25%" align="center" valign="center">
+                    <image align="center" valign="top" id="dSubObjectiveImage" width="90%"/>
                     <panel height="*" />
                 </panel>
-                <panel childLayout="overlay" width="*" align="left" valign="top" backgroundColor="#f508">
+                <panel childLayout="overlay" width="*" align="left" valign="top" backgroundColor="#f508" height="100%">
                     <control name="scrollPanel" horizontal="false" stepSizeY="30">
                         <!-- TODO maybe use Table ? -->
                         <panel childLayout="horizontal" width="100%">

--- a/src/main/java/toniarts/openkeeper/game/state/MainMenuScreenController.java
+++ b/src/main/java/toniarts/openkeeper/game/state/MainMenuScreenController.java
@@ -1263,10 +1263,8 @@ public final class MainMenuScreenController implements IMainMenuScreenController
 
         String objectiveImage = AssetUtils.getCanonicalAssetKey(String.format(OBJECTIVE_IMAGE_URL, gameLevel.getName(), 0));
         try {
-            img = nifty.createImage(objectiveImage, false);
+            img = nifty.createImage(objectiveImage, true);
             mainObjectiveImage.getRenderer(ImageRenderer.class).setImage(img);
-            mainObjectiveImage.setWidth(img.getWidth());
-            mainObjectiveImage.setHeight(img.getHeight());
             mainObjectiveImage.show();
         } catch (Exception e) {
             logger.log(Logger.Level.WARNING, "Can''t find image {0}", objectiveImage);
@@ -1292,10 +1290,8 @@ public final class MainMenuScreenController implements IMainMenuScreenController
             if (state.selectedLevel instanceof CampaignLevel lvl && lvl.getType().equals(LevelType.Level)) {
                 objectiveImage = AssetUtils.getCanonicalAssetKey(String.format(OBJECTIVE_IMAGE_URL, gameLevel.getName(), 1));
                 try {
-                    img = nifty.createImage(objectiveImage, false);
+                    img = nifty.createImage(objectiveImage, true);
                     subObjectiveImage.getRenderer(ImageRenderer.class).setImage(img);
-                    subObjectiveImage.setWidth(img.getWidth());
-                    subObjectiveImage.setHeight(img.getHeight());
                     subObjectiveImage.show();
                 } catch (Exception e) {
                     logger.log(Logger.Level.WARNING, "Can''t find image {0}", objectiveImage);
@@ -1329,11 +1325,10 @@ public final class MainMenuScreenController implements IMainMenuScreenController
         boolean campaign = state.isDebriefingCampaign();
         String objectiveImage = AssetUtils.getCanonicalAssetKey(String.format(OBJECTIVE_IMAGE_URL, gameLevel.getName(), 0));
         try {
-            NiftyImage img = nifty.createImage(objectiveImage, false);
-            mainObjectiveImage.getRenderer(ImageRenderer.class).setImage(img);
-            mainObjectiveImage.setWidth(img.getWidth());
-            mainObjectiveImage.setHeight(img.getHeight());
+            NiftyImage img = nifty.createImage(objectiveImage, true);
             mainObjectiveImage.show();
+            mainObjectiveImage.getRenderer(ImageRenderer.class).setImage(img);
+
         } catch (Exception e) {
             logger.log(Logger.Level.WARNING, "Can''t find image {0}", objectiveImage);
             mainObjectiveImage.hide();
@@ -1347,10 +1342,8 @@ public final class MainMenuScreenController implements IMainMenuScreenController
         if (campaign && state.selectedLevel instanceof CampaignLevel lvl && lvl.getType().equals(LevelType.Level)) {
             objectiveImage = AssetUtils.getCanonicalAssetKey(String.format(OBJECTIVE_IMAGE_URL, gameLevel.getName(), 1));
             try {
-                NiftyImage img = nifty.createImage(objectiveImage, false);
+                NiftyImage img = nifty.createImage(objectiveImage, true);
                 subObjectiveImage.getRenderer(ImageRenderer.class).setImage(img);
-                subObjectiveImage.setWidth(img.getWidth());
-                subObjectiveImage.setHeight(img.getHeight());
                 subObjectiveImage.show();
             } catch (Exception e) {
                 logger.log(Logger.Level.WARNING, "Can''t find image {0}", objectiveImage);

--- a/src/main/java/toniarts/openkeeper/gui/nifty/effect/TextGlowEffect.java
+++ b/src/main/java/toniarts/openkeeper/gui/nifty/effect/TextGlowEffect.java
@@ -31,22 +31,51 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
- * Renders a subtle glow around the element's text. The glow is drawn, with the
- * configured color and alpha, as concentric rings around the text so that it
- * appears as a soft halo behind the actual text. Use in conjunction with
- * {@code onActive}, {@code timeType="infinite"} and {@code neverStopRendering="true"}
- * to render the effect on every frame while the element's screen is active.
+ * Renders a subtle glow around the element's text. The glow approximates a
+ * Gaussian blur by drawing the text multiple times at all offsets within a
+ * small radius, with the alpha falling off like a normal distribution as the
+ * offset grows. This produces a soft, blurred halo behind the actual text. Use
+ * in conjunction with {@code onActive}, {@code timeType="infinite"} and
+ * {@code neverStopRendering="true"} to render the effect on every frame while
+ * the element's screen is active.
  *
  * @author Toni Helenius <helenius.toni@gmail.com>
  */
 public final class TextGlowEffect implements EffectImpl {
 
     /**
-     * The eight unit directions (including diagonals) around a text position that the glow is drawn towards.
+     * The maximum blur radius supported by the precomputed offset rings.
      */
-    private static final int[][] DIRECTION_OFFSETS = {
-        { -1, 0 }, { 1, 0 }, { 0, -1 }, { 0, 1 }, { -1, -1 }, { 1, -1 }, { -1, 1 }, { 1, 1 }
-    };
+    private static final int MAX_DISTANCE = 8;
+
+    /**
+     * For every ring radius {@code r}, all integer offsets whose Chebyshev
+     * distance to the origin is exactly {@code r}. Together the rings cover
+     * every point around the text exactly once.
+     */
+    private static final int[][][] RING_OFFSETS = buildRingOffsets();
+
+    /**
+     * Precomputes the ring offsets for all radii up to {@link #MAX_DISTANCE}.
+     *
+     * @return the ring offsets
+     */
+    private static int[][][] buildRingOffsets() {
+        int[][][] rings = new int[MAX_DISTANCE + 1][][];
+        for (int radius = 1; radius <= MAX_DISTANCE; radius++) {
+            int[][] offsets = new int[8 * radius][];
+            int index = 0;
+            for (int dx = -radius; dx <= radius; dx++) {
+                for (int dy = -radius; dy <= radius; dy++) {
+                    if (Math.max(Math.abs(dx), Math.abs(dy)) == radius) {
+                        offsets[index++] = new int[] { dx, dy };
+                    }
+                }
+            }
+            rings[radius] = offsets;
+        }
+        return rings;
+    }
 
     /**
      * The glow color. When {@code null}, the element's own text color is used.
@@ -116,6 +145,11 @@ public final class TextGlowEffect implements EffectImpl {
             return;
         }
 
+        int glowDistance = Math.min(Math.max(distance, 1), MAX_DISTANCE);
+        // a Gaussian with sigma = half the radius so that the glow reaches zero
+        // towards the outermost ring
+        float sigmaSquared = 2.0f * (glowDistance / 2.0f) * (glowDistance / 2.0f);
+
         r.saveStates();
         r.setFont(font);
 
@@ -126,13 +160,16 @@ public final class TextGlowEffect implements EffectImpl {
             int lineX = element.getX()
                     + horizontalTextOffset(font.getWidth(line), element.getWidth(), textRenderer.getTextHAlign());
             int lineY = element.getY() + startY + i * font.getHeight();
-            for (int ring = 1; ring <= distance; ring++) {
-                // the glow fades out towards the outer rings
-                float factor = 1.0f - (float) (ring - 1) / distance;
-                Color ringColor = new Color(baseColor, alpha * factor);
+            // draw the outer rings first so that the inner, brighter rings overlay them
+            for (int ring = glowDistance; ring >= 1; ring--) {
+                float weight = (float) Math.exp(-(ring * ring) / sigmaSquared);
+                if (weight < 0.01f) {
+                    continue;
+                }
+                Color ringColor = new Color(baseColor, alpha * weight);
                 r.setColor(ringColor);
-                for (int[] offset : DIRECTION_OFFSETS) {
-                    r.renderText(line, lineX + offset[0] * ring, lineY + offset[1] * ring, -1, -1, ringColor);
+                for (int[] offset : RING_OFFSETS[ring]) {
+                    r.renderText(line, lineX + offset[0], lineY + offset[1], -1, -1, ringColor);
                 }
             }
         }

--- a/src/main/java/toniarts/openkeeper/gui/nifty/effect/TextGlowEffect.java
+++ b/src/main/java/toniarts/openkeeper/gui/nifty/effect/TextGlowEffect.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright (C) 2014-2024 OpenKeeper
+ *
+ * OpenKeeper is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * OpenKeeper is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenKeeper.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package toniarts.openkeeper.gui.nifty.effect;
+
+import de.lessvoid.nifty.Nifty;
+import de.lessvoid.nifty.effects.EffectImpl;
+import de.lessvoid.nifty.effects.EffectProperties;
+import de.lessvoid.nifty.effects.Falloff;
+import de.lessvoid.nifty.elements.Element;
+import de.lessvoid.nifty.elements.render.TextRenderer;
+import de.lessvoid.nifty.layout.align.HorizontalAlign;
+import de.lessvoid.nifty.layout.align.VerticalAlign;
+import de.lessvoid.nifty.render.NiftyRenderEngine;
+import de.lessvoid.nifty.spi.render.RenderFont;
+import de.lessvoid.nifty.tools.Color;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Renders a subtle glow around the element's text. The glow is drawn, with the
+ * configured color and alpha, as concentric rings around the text so that it
+ * appears as a soft halo behind the actual text. Use in conjunction with
+ * {@code onActive}, {@code timeType="infinite"} and {@code neverStopRendering="true"}
+ * to render the effect on every frame while the element's screen is active.
+ *
+ * @author Toni Helenius <helenius.toni@gmail.com>
+ */
+public final class TextGlowEffect implements EffectImpl {
+
+    /**
+     * The eight unit directions (including diagonals) around a text position that the glow is drawn towards.
+     */
+    private static final int[][] DIRECTION_OFFSETS = {
+        { -1, 0 }, { 1, 0 }, { 0, -1 }, { 0, 1 }, { -1, -1 }, { 1, -1 }, { -1, 1 }, { 1, 1 }
+    };
+
+    /**
+     * The glow color. When {@code null}, the element's own text color is used.
+     */
+    @Nullable
+    private Color glowColor;
+
+    /**
+     * The glow opacity.
+     */
+    private float alpha = 0.7f;
+
+    /**
+     * The glow spread in pixels.
+     */
+    private int distance = 1;
+
+    /**
+     * initialize.
+     *
+     * @param nifty Nifty
+     * @param element Element
+     * @param parameter Parameter
+     */
+    @Override
+    public void activate(
+            @Nonnull final Nifty nifty,
+            @Nonnull final Element element,
+            @Nonnull final EffectProperties parameter) {
+        String color = parameter.getProperty("color");
+        glowColor = color != null ? new Color(color) : null;
+        alpha = Float.parseFloat(parameter.getProperty("alpha", "0.7"));
+        distance = Integer.parseInt(parameter.getProperty("distance", "1"));
+    }
+
+    /**
+     * execute the effect.
+     *
+     * @param element the Element
+     * @param normalizedTime TimeInterpolator to use
+     * @param falloff falloff value
+     * @param r RenderDevice to use
+     */
+    @Override
+    public void execute(
+            @Nonnull final Element element,
+            final float normalizedTime,
+            @Nullable final Falloff falloff,
+            @Nonnull final NiftyRenderEngine r) {
+        TextRenderer textRenderer = element.getRenderer(TextRenderer.class);
+        if (textRenderer == null) {
+            return;
+        }
+        RenderFont font = textRenderer.getFont();
+        if (font == null) {
+            font = r.getFont();
+        }
+        if (font == null) {
+            return;
+        }
+        String[] lines = textRenderer.getWrappedText().split("\n", -1);
+        if (lines.length == 0 || (lines.length == 1 && lines[0].isEmpty())) {
+            return;
+        }
+        Color baseColor = glowColor != null ? glowColor : textRenderer.getColor();
+        if (baseColor == null) {
+            return;
+        }
+
+        r.saveStates();
+        r.setFont(font);
+
+        int startY = verticalTextOffset(lines.length * font.getHeight(), element.getHeight(),
+                textRenderer.getTextVAlign());
+        for (int i = 0; i < lines.length; i++) {
+            String line = lines[i];
+            int lineX = element.getX()
+                    + horizontalTextOffset(font.getWidth(line), element.getWidth(), textRenderer.getTextHAlign());
+            int lineY = element.getY() + startY + i * font.getHeight();
+            for (int ring = 1; ring <= distance; ring++) {
+                // the glow fades out towards the outer rings
+                float factor = 1.0f - (float) (ring - 1) / distance;
+                Color ringColor = new Color(baseColor, alpha * factor);
+                r.setColor(ringColor);
+                for (int[] offset : DIRECTION_OFFSETS) {
+                    r.renderText(line, lineX + offset[0] * ring, lineY + offset[1] * ring, -1, -1, ringColor);
+                }
+            }
+        }
+
+        r.restoreStates();
+    }
+
+    /**
+     * deactivate the effect.
+     */
+    @Override
+    public void deactivate() {
+    }
+
+    /**
+     * Calculates the horizontal offset for the given alignment, the same way as
+     * {@link TextRenderer} does when rendering the actual text.
+     *
+     * @param textWidth the width of the text
+     * @param elementWidth the width of the element
+     * @param align the horizontal alignment
+     * @return the horizontal offset
+     */
+    private static int horizontalTextOffset(final int textWidth, final int elementWidth,
+            final HorizontalAlign align) {
+        if (align == HorizontalAlign.center) {
+            return (elementWidth - textWidth) / 2;
+        } else if (align == HorizontalAlign.right) {
+            return elementWidth - textWidth;
+        }
+        return 0;
+    }
+
+    /**
+     * Calculates the vertical offset for the given alignment, the same way as
+     * {@link TextRenderer} does when rendering the actual text.
+     *
+     * @param textHeight the height of the text
+     * @param elementHeight the height of the element
+     * @param align the vertical alignment
+     * @return the vertical offset
+     */
+    private static int verticalTextOffset(final int textHeight, final int elementHeight,
+            final VerticalAlign align) {
+        if (align == VerticalAlign.center) {
+            return (elementHeight - textHeight) / 2;
+        } else if (align == VerticalAlign.bottom) {
+            return elementHeight - textHeight;
+        }
+        return 0;
+    }
+
+}


### PR DESCRIPTION
* Objective images are now larger (25% of screen)
* Title and Subtile have now a glow

<img width="1116" height="626" alt="grafik" src="https://github.com/user-attachments/assets/c257fdba-db84-485c-b444-43e890d7bfba" />

Here a comparision to the original game:
<img width="1895" height="1190" alt="grafik" src="https://github.com/user-attachments/assets/9e88348f-60af-48a4-acc8-d2b3d277c086" />
